### PR TITLE
docs: fix language switching

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,6 @@ theme:
   favicon: assets/logo/logo.png
   features:
     - navigation.tracking
-    - navigation.instant
     - navigation.indexes
     - content.code.annotate
 
@@ -51,10 +50,10 @@ watch:
 extra:
   alternate:
     - name: English
-      link: /confit/en/
+      link: ./en/
       lang: en
     - name: Français
-      link: /confit/fr/
+      link: ./fr/
       lang: fr
   version:
     provider: mike


### PR DESCRIPTION
## Description

Fixes docs language switching by disabling `navigation.instant` (https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading)

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
