### PR TITLE
feat: allow config in command decorator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Pending
+
+- Allow passing configuration(s) directly to `@app.command()`
+
 # v0.2.1 - 11-05-2023
 
 - Fix un-allowed kwargs: accepted signatures are `fn(paramA, paramB=..., ... **kwargs)`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The goal of this PR is to add an `config` argument in `@app.command`. As such, it allows to pass one (or more) `Config` object to the underlying script. All additional configurations provided through the CLI will still be used via merging.

```python
@app.command("script", config=Config(...))
def run(...):
    ...
```

Then  `python -m script.py` will run as is

<!--- Describe the changes. -->

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
