### PR TITLE
Better errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   # ruff
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.0.245'
+    rev: 'v0.0.270'
     hooks:
       - id: ruff
         args: ['--fix', '--config', 'pyproject.toml']

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,23 @@
 # Changelog
 
-# v0.2.1 - 11-05-2023
+## Unreleased
+
+### Added
+
+- Improve validation errors merging and display. By default, confit related frames and exception causes
+  in the traceback are hidden.
+- Show inner-confit traceback and exception chains if `CONFIT_DEBUG` env var is true
+
+### Fixed
+
+- If the `seed` is given a default value in CLI, it can now be used by confit when no seed is given
+
+## v0.2.1 - 11-05-2023
 
 - Fix un-allowed kwargs: accepted signatures are `fn(paramA, paramB=..., ... **kwargs)`
 
 
-# v0.2.0 - 05-04-2023
+## v0.2.0 - 05-04-2023
 
 - `Config.merge(...)` now only copies collections (not the underlying data) and doesn't split keys around dots
 - `__path__` option has been removed (having a override_structure in .to_str() would be better)
@@ -15,7 +27,7 @@
 - Add the `invoker` option to `.register(...)` to modify the arguments of the call to the registered function or do something with the result
 - User defined `class registry` should now inherit from `RegistryCollection`
 
-# v0.1.5 - 02-03-2023
+## v0.1.5 - 02-03-2023
 
 - Verify the signature when registering rather than during a call
 - Allow `**kwargs`

--- a/confit/cli.py
+++ b/confit/cli.py
@@ -129,6 +129,8 @@ class Cli(Typer):
                 try:
                     resolved_config = config.resolve(registry=registry)
                     default_seed = validated.model.__fields__.get("seed")
+                    if default_seed is not None:
+                        default_seed = default_seed.get_default()
                     seed = config.get(name, {}).get("seed", default_seed)
                     if seed is not None:
                         set_seed(seed)

--- a/confit/cli.py
+++ b/confit/cli.py
@@ -12,6 +12,7 @@ from .config import Config, merge_from_disk
 from .errors import patch_errors
 from .registry import validate_arguments
 from .utils.random import set_seed
+from .utils.settings import is_debug
 from .utils.xjson import loads
 
 
@@ -152,13 +153,15 @@ class Cli(Typer):
                         e.raw_errors,
                         (name,),
                     )
+                    if is_debug():
+                        raise e
                     try:
                         import rich
 
                         console = rich.console.Console(stderr=True)
                         console.print("Validation error:", style="red", end=" ")
                         console.print(str(e))
-                    except ImportError:
+                    except ImportError:  # pragma: no cover
                         print("Validation error:", file=sys.stderr, end=" ")
                         print(str(e), file=sys.stderr)
                     sys.exit(1)

--- a/confit/cli.py
+++ b/confit/cli.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
-import rich
 from pydantic import ValidationError
 from typer import Context, Typer, colors, secho
 from typer.core import TyperCommand
@@ -153,9 +152,15 @@ class Cli(Typer):
                         e.raw_errors,
                         (name,),
                     )
-                    console = rich.get_console()
-                    console.print("Validation error:", style="red", end=" ")
-                    console.print(str(e))
+                    try:
+                        import rich
+
+                        console = rich.console.Console(stderr=True)
+                        console.print("Validation error:", style="red", end=" ")
+                        console.print(str(e))
+                    except ImportError:
+                        print("Validation error:", file=sys.stderr, end=" ")
+                        print(str(e), file=sys.stderr)
                     sys.exit(1)
 
             return validated

--- a/confit/errors.py
+++ b/confit/errors.py
@@ -9,6 +9,7 @@ from pydantic.error_wrappers import (
 )
 
 from confit.utils.collections import join_path
+from confit.utils.settings import is_debug
 from confit.utils.xjson import Reference
 
 Loc = Tuple[Union[int, str]]
@@ -66,6 +67,8 @@ def remove_lib_from_traceback(tb):
     Remove the lib folder from the traceback
     """
     # compare package to module in f_globals
+    if is_debug():
+        return tb
     if tb is not None and tb.tb_frame.f_globals.get("__package__") == __package__:
         return remove_lib_from_traceback(tb.tb_next)
     if tb is None or tb.tb_next is None:

--- a/confit/errors.py
+++ b/confit/errors.py
@@ -1,0 +1,233 @@
+from textwrap import indent
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import pydantic
+from pydantic.error_wrappers import (
+    ErrorWrapper,
+    ValidationError,
+    get_exc_type,
+)
+
+from confit.utils.collections import join_path
+from confit.utils.xjson import Reference
+
+Loc = Tuple[Union[int, str]]
+
+
+class MissingReference(Exception):
+    """
+    Raised when one or multiple references cannot be resolved.
+    """
+
+    def __init__(self, ref: Reference):
+        """
+        Parameters
+        ----------
+        ref: Reference
+            The reference that could not be resolved.
+        """
+        self.ref = ref
+        super().__init__()
+
+    def __str__(self):
+        """
+        String representation of the exception
+        """
+        return "Could not interpolate the following reference: {}".format(self.ref)
+
+
+class CyclicReferenceError(Exception):
+    """
+    Raised when a cyclic reference is detected.
+    """
+
+    def __init__(self, path: Loc):
+        """
+        Parameters
+        ----------
+        path: Loc
+            The path of the cyclic reference
+        """
+        self.path = path
+        super().__init__()
+
+    def __str__(self):
+        """
+        String representation of the exception
+        """
+        return "Cyclic reference detected at {}".format(join_path(self.path))
+
+
+PATCHED_ERRORS_CLS = {}
+
+
+def remove_lib_from_traceback(tb):
+    """
+    Remove the lib folder from the traceback
+    """
+    # compare package to module in f_globals
+    if tb is not None and tb.tb_frame.f_globals.get("__package__") == __package__:
+        return remove_lib_from_traceback(tb.tb_next)
+    if tb is None or tb.tb_next is None:
+        return tb
+    tb.tb_next = remove_lib_from_traceback(tb.tb_next)
+    return tb
+
+
+class ConfitValidationError(pydantic.ValidationError):
+    __slots__ = "raw_errors", "model", "_error_cache"
+
+    def __init__(
+        self,
+        errors: Sequence,
+        model: Optional[Any] = None,
+        name: Optional[str] = None,
+    ) -> None:
+        self.raw_errors = errors
+        self.model = model
+        self.name = name or (model.__name__ if model is not None else None)
+        self._error_cache = None
+
+    def __str__(self) -> str:
+        errors = self.errors()
+        no_errors = len(errors)
+        err_list_str = "\n".join(
+            "{loc_str}\n{msg}".format(
+                loc_str="-> " + ".".join(str(e) for e in err["loc"]),
+                msg=err["msg"],
+            )
+            for err in self.errors()
+        )
+        name_str = (" for " + self.name + "()") if self.name is not None else ""
+        return (
+            f'{no_errors} validation error{"" if no_errors == 1 else "s"}{name_str}\n'
+            f"{err_list_str}"
+        )
+
+    def errors(self) -> List:
+        error_dicts = []
+        for err in flatten_errors(self.raw_errors):
+            msg = (
+                err.exc.msg_template.format(**err.exc.__dict__)
+                if hasattr(err.exc, "msg_template")
+                else str(err.exc)
+            )
+            error_dicts.append(
+                {
+                    "loc": err.loc_tuple(),
+                    "msg": indent(msg, "   "),
+                    "ctx": err.exc.__dict__,
+                    "type": get_exc_type(err.exc.__class__),
+                }
+            )
+        return error_dicts
+
+    def __repr_args__(self):
+        return [("model", self.name), ("errors", self.errors())]
+
+
+def patch_errors(
+    errors: Union[Sequence[ErrorWrapper], ErrorWrapper],
+    path: Loc,
+    values: Dict = None,
+    model: Optional[pydantic.BaseModel] = None,
+):
+    """
+    Patch the location of the errors to add the `path` prefix and complete
+    the errors with the actual value if it is available.
+    This is useful when the errors are raised in a sub-dict of the config.
+
+    Parameters
+    ----------
+    errors: Union[Sequence[ErrorWrapper], ErrorWrapper]
+        The pydantic errors to patch
+    path: Loc
+        The path to add to the errors
+    values: Dict
+        The values of the config
+    post: bool
+        Whether to add the path after the error location
+
+    Returns
+    -------
+    Union[Sequence[ErrorWrapper], ErrorWrapper]
+        The patched errors
+    """
+    if isinstance(errors, list):
+        res = []
+        for error in errors:
+            res.extend(patch_errors(error, path, values, model))
+        return res
+    if isinstance(errors, ErrorWrapper) and isinstance(errors.exc, ValidationError):
+        try:
+            field_model = model
+            for part in errors.loc_tuple():
+                if not issubclass(field_model, pydantic.BaseModel) and issubclass(
+                    field_model.vd.model, pydantic.BaseModel
+                ):
+                    field_model = field_model.vd.model
+                field_model = field_model.__fields__[part].type_
+            if (
+                field_model is errors.exc.model
+                or field_model.vd.model is errors.exc.model
+            ):
+                return patch_errors(
+                    errors.exc.raw_errors, (*path, *errors.loc_tuple()), values, model
+                )
+        except (KeyError, AttributeError):
+            pass
+
+    if (
+        isinstance(errors.exc, pydantic.errors.PydanticErrorMixin)
+        and values is not None
+        and "actual_value" not in errors.exc.__dict__
+        and errors.loc_tuple()
+        and errors.loc_tuple()[0] in values
+    ):
+        actual_value = values
+        for key in errors.loc_tuple():
+            actual_value = actual_value[key]
+        cls = errors.exc.__class__
+        if cls not in PATCHED_ERRORS_CLS:
+
+            def error_str(self):
+                s = cls.__str__(self)
+                s = (
+                    s + f", got {self.actual_value} ({self.actual_type})"
+                    if hasattr(self, "actual_value")
+                    else s
+                )
+                return s
+
+            PATCHED_ERRORS_CLS[cls] = type(
+                cls.__name__,
+                (cls,),
+                {
+                    "msg_template": cls.msg_template
+                    + ", got {actual_value} ({actual_type})"
+                }
+                if hasattr(cls, "msg_template")
+                else {
+                    "__str__": error_str,
+                },
+            )
+        errors.exc.__class__ = PATCHED_ERRORS_CLS[cls]
+        vrepr = repr(actual_value)
+        errors.exc.actual_value = vrepr[:50] + "..." if len(vrepr) > 50 else vrepr
+        errors.exc.actual_type = type(actual_value).__name__
+    return [
+        ErrorWrapper(
+            errors.exc,
+            (*path, *errors.loc_tuple()),
+        )
+    ]
+
+
+def flatten_errors(
+    errors: Union[Sequence[ErrorWrapper], ErrorWrapper],
+) -> Sequence[ErrorWrapper]:
+    if isinstance(errors, list):
+        for err in errors:
+            yield from flatten_errors(err)
+    else:
+        yield errors

--- a/confit/errors.py
+++ b/confit/errors.py
@@ -165,10 +165,10 @@ def patch_errors(
         try:
             field_model = model
             for part in errors.loc_tuple():
-                if not issubclass(field_model, pydantic.BaseModel) and issubclass(
-                    field_model.vd.model, pydantic.BaseModel
-                ):
-                    field_model = field_model.vd.model
+                # if not issubclass(field_model, pydantic.BaseModel) and issubclass(
+                #     field_model.vd.model, pydantic.BaseModel
+                # ):
+                #     field_model = field_model.vd.model
                 field_model = field_model.__fields__[part].type_
             if (
                 field_model is errors.exc.model
@@ -177,7 +177,7 @@ def patch_errors(
                 return patch_errors(
                     errors.exc.raw_errors, (*path, *errors.loc_tuple()), values, model
                 )
-        except (KeyError, AttributeError):
+        except (KeyError, AttributeError):  # pragma: no cover
             pass
 
     if (

--- a/confit/registry.py
+++ b/confit/registry.py
@@ -201,8 +201,6 @@ def validate_arguments(
                         invoker=invoker,
                         callee=_func,
                     )
-                except ConfitValidationError as e:
-                    raise e.with_traceback(None) from None
                 except Exception as e:
                     if not is_debug():
                         e.__cause__ = None
@@ -231,8 +229,6 @@ def validate_arguments(
                         invoker=invoker,
                         callee=_func,
                     )
-                except ConfitValidationError as e:
-                    raise e.with_traceback(None) from None
                 except Exception as e:
                     if not is_debug():
                         e.__cause__ = None

--- a/confit/registry.py
+++ b/confit/registry.py
@@ -13,6 +13,7 @@ from confit.errors import (
     patch_errors,
     remove_lib_from_traceback,
 )
+from confit.utils.settings import is_debug
 
 
 class SignatureError(TypeError):
@@ -80,7 +81,10 @@ def _resolve_and_validate_call(
             )
             if non_valid_errors:
                 raise e from non_valid_errors[0].exc
-            raise e from None
+            if not is_debug():
+                e.__cause__ = None
+                e.__suppress_context__ = True
+            raise e
         if not use_self:
             resolved = returned
         return resolved
@@ -200,9 +204,10 @@ def validate_arguments(
                 except ConfitValidationError as e:
                     raise e.with_traceback(None) from None
                 except Exception as e:
-                    raise e.with_traceback(
-                        remove_lib_from_traceback(e.__traceback__)
-                    ) from None
+                    if not is_debug():
+                        e.__cause__ = None
+                        e.__suppress_context__ = True
+                    raise e.with_traceback(remove_lib_from_traceback(e.__traceback__))
 
             _func.vd = vd  # type: ignore
             _func.__get_validators__ = __get_validators__  # type: ignore
@@ -229,9 +234,10 @@ def validate_arguments(
                 except ConfitValidationError as e:
                     raise e.with_traceback(None) from None
                 except Exception as e:
-                    raise e.with_traceback(
-                        remove_lib_from_traceback(e.__traceback__)
-                    ) from None
+                    if not is_debug():
+                        e.__cause__ = None
+                        e.__suppress_context__ = True
+                    raise e.with_traceback(remove_lib_from_traceback(e.__traceback__))
 
             wrapper_function.vd = vd  # type: ignore
             wrapper_function.validate = vd.init_model_instance  # type: ignore

--- a/confit/utils/settings.py
+++ b/confit/utils/settings.py
@@ -1,0 +1,16 @@
+import os
+from functools import lru_cache
+
+from confit.utils.xjson import loads
+
+
+@lru_cache(maxsize=1)
+def parse_debug(value):
+    try:
+        return bool(loads(value))
+    except Exception:
+        return True
+
+
+def is_debug():
+    return parse_debug(os.environ.get("CONFIT_DEBUG", "0"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pre-commit>=2.18.1,<3.0",
     "pytest>=7.1.1,<8.0",
     "pytest-cov>=3.0.0,<4.0",
+    "rich",
 ]
 
 [tool.setuptools.dynamic]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,14 +71,15 @@ def test_cli_missing(change_test_dir):
             "--seed",
             "42",
         ],
+        env={"CONFIT_DEBUG": "true"},
     )
     assert result.exit_code == 1
-    assert str(result.stdout) == (
-        "Validation error: 2 validation errors for test_cli.function()\n"
+    assert str(result.exception) == (
+        "2 validation errors for test_cli.function()\n"
         "-> script.modelA.submodel\n"
         "   field required\n"
         "-> script.modelB\n"
-        "   field required\n"
+        "   field required"
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,7 @@ def test_cli_working(change_test_dir):
     assert "Other: 4" in result.stdout
 
 
-def test_cli_missing(change_test_dir):
+def test_cli_missing_debug(change_test_dir):
     result = runner.invoke(
         app,
         [
@@ -81,6 +81,28 @@ def test_cli_missing(change_test_dir):
         "-> script.modelB\n"
         "   field required"
     )
+
+
+def test_cli_missing_no_debug(change_test_dir):
+    result = runner.invoke(
+        app,
+        [
+            "--modelA.date",
+            "2010-10-10",
+            "--other",
+            "4",
+            "--seed",
+            "42",
+        ],
+    )
+    assert result.exit_code == 1
+    assert (
+        "2 validation errors for test_cli.function()\n"
+        "-> script.modelA.submodel\n"
+        "   field required\n"
+        "-> script.modelB\n"
+        "   field required"
+    ) in str(result.stdout)
 
 
 def test_cli_merge(change_test_dir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,13 @@ def test_cli_missing(change_test_dir):
         ],
     )
     assert result.exit_code == 1
-    assert "Validation error" in result.stdout
+    assert str(result.stdout) == (
+        "Validation error: 2 validation errors for test_cli.function()\n"
+        "-> script.modelA.submodel\n"
+        "   field required\n"
+        "-> script.modelB\n"
+        "   field required\n"
+    )
 
 
 def test_cli_merge(change_test_dir):

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -356,7 +356,8 @@ def test_type_hinted_instantiation_error():
     assert str(exc_info.value) == (
         "1 validation error for Function\n"
         "embedding -> value\n"
-        "  value is not a valid float (type=type_error.float)"
+        "  value is not a valid float, got 'ok' (str) (type=type_error.float; "
+        "actual_value='ok'; actual_type=str)"
     )
 
 
@@ -370,9 +371,9 @@ def test_factory_instantiation_error():
         """
         ).resolve(registry=registry)
     assert str(exc_info.value) == (
-        "1 validation error for SubModel\n"
-        "embedding -> value\n"
-        "  value is not a valid float (type=type_error.float)"
+        "1 validation error for SubModel()\n"
+        "-> embedding.value\n"
+        "   value is not a valid float, got 'ok' (str)"
     )
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,6 +3,7 @@ import inspect
 from typing import Any, Callable, Dict, Optional
 
 import catalogue
+import pytest
 from pytest import fixture
 
 from confit import Config, Registry
@@ -148,3 +149,13 @@ def test_default_config_invoker(registry):
         "@misc": "submodel",
         "value": 28.0,
     }
+
+
+def test_missing(registry):
+    with pytest.raises(catalogue.RegistryError) as e:
+        registry.misc.get("clearly_missing_function")
+
+    assert (
+        "Can't find 'clearly_missing_function' in registry mytest -> misc. "
+        "Available names:" in str(e.value)
+    )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from pydantic import StrictBool, ValidationError
 from typing_extensions import Literal
@@ -114,3 +116,22 @@ def test_fail_init():
         "   -> raise_attribute\n"
         "      field required"
     )
+
+
+def test_debug():
+    try:
+        os.environ["CONFIT_DEBUG"] = "true"
+
+        @validate_arguments()
+        def test(val: Literal["ok", "ko"]):
+            return val
+
+        with pytest.raises(ConfitValidationError) as e:
+            test("not ok")
+        assert str(e.value) == (
+            "1 validation error for test_validate.test_debug.<locals>.test()\n"
+            "-> val\n"
+            "   unexpected value; permitted: 'ok', 'ko', got 'not ok' (str)"
+        )
+    finally:
+        os.environ.pop("CONFIT_DEBUG", None)


### PR DESCRIPTION
## Description

This PR improves the handling of validation errors:
- merging multiple validation errors during nested parameter validation / casting
- showing the actual input value if a check fails
- preparing the refacto of edsnlp

For instance:
```
Validation error: 5 validation errors for __main__.train()
-> train.nlp.components.to_ents
   value is not a bool, string or list of strings, got {'ok': False} (dict)
-> train.nlp.components.to_span_groups
   value is not a valid float, got 'pseudo-rb' (str)
-> train.nlp.components.window
   value is not a valid integer, got 'string' (str)
-> train.nlp.components.embedding
   instance of TorchComponent expected, got <eds_pseudonymisation.pipelines.clean_entities.Cle... (CleanEntities)
-> train.batch_size
   value is not a valid integer, got 'ok16' (str)
```

Additionally, it also fixes cli calls when the seed parameter (if any) is left to its default value

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
