### PR TITLE
v0.4.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4.2 - 31-08-2023
+
+### Fixed
+
+- Re-enable extra/duplicate arg errors and uniformize between pydantic v1/v2
+- Add pydantic-core dependency for jsonable types during dump
+
 ## v0.4.1 - 29-08-2023
 
 ### Fixed

--- a/confit/__init__.py
+++ b/confit/__init__.py
@@ -8,4 +8,4 @@ from .registry import (
     RegistryCollection,  # noqa F401
 )
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/confit/cli.py
+++ b/confit/cli.py
@@ -154,7 +154,7 @@ class Cli(Typer):
                         e.raw_errors,
                         (name,),
                     )
-                    if is_debug():
+                    if is_debug() or e.__cause__ is not None:
                         raise e
                     try:
                         import rich

--- a/confit/registry.py
+++ b/confit/registry.py
@@ -246,7 +246,9 @@ def validate_arguments(
                         callee=_func,
                     )
                 except Exception as e:
-                    if not is_debug():
+                    if not is_debug() and isinstance(
+                        e.__context__, (ValidationError, LegacyValidationError)
+                    ):
                         e.__cause__ = None
                         e.__suppress_context__ = True
                     raise e.with_traceback(remove_lib_from_traceback(e.__traceback__))
@@ -277,7 +279,9 @@ def validate_arguments(
                         callee=_func,
                     )
                 except Exception as e:
-                    if not is_debug():
+                    if not is_debug() and isinstance(
+                        e.__cause__, (ValidationError, LegacyValidationError)
+                    ):
                         e.__cause__ = None
                         e.__suppress_context__ = True
                     raise e.with_traceback(remove_lib_from_traceback(e.__traceback__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "lark>=1.1.5,<2.0",
     "pydantic>=1.2,<3.0",
     "typer>=0.6.1,<1.0",
+    "pydantic-core>=0.20"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -525,3 +525,8 @@ def test_root_level_config_error():
         Config({"ok": "ok"}).to_str()
 
     assert "root level config" in str(exc_info.value)
+
+
+def test_simple_dump():
+    config = Config({"section": {"date": datetime.date.today()}})
+    assert config.to_str() == '[section]\ndate = "2023-08-31"\n\n'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Re-enable extra/duplicate arg errors and uniformize between pydantic v1/v2
- Add pydantic-core dependency for jsonable types during dump

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
