### PR TITLE
Parameter for deprecated names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `deprecated` parameter to register an object under multiple names with deprecation warnings
+
+### Fixed
+
+- Stop interpreting type errors as validation errors when executing a validated function
+
 ## v0.4.3 - 31-08-2023
 
 ### Fixed

--- a/confit/__init__.py
+++ b/confit/__init__.py
@@ -6,6 +6,7 @@ from .registry import (
     get_default_registry,  # noqa F401
     set_default_registry,  # noqa F401
     RegistryCollection,  # noqa F401
+    VisibleDeprecationWarning,  # noqa F401
 )
 
 __version__ = "0.4.3"

--- a/confit/config.py
+++ b/confit/config.py
@@ -138,7 +138,7 @@ class Config(dict):
         s = Config.to_str(self)
         Path(path).write_text(s)
 
-    def serialize(self):
+    def serialize(self: Any):
         """
         Try to convert non-serializable objects using the RESOLVED_TO_CONFIG object
         back to their original catalogue + params form

--- a/confit/errors.py
+++ b/confit/errors.py
@@ -327,3 +327,16 @@ def flatten_errors(
             yield from flatten_errors(err)
     else:
         yield errors
+
+
+def convert_type_error(err, pydantic_func, callee):
+    loc_suffix = ()
+    if str(err).startswith("multiple values for argument"):
+        loc_suffix = ("v__duplicate_kwargs",)
+    elif str(err).startswith("unexpected keyword argument"):
+        loc_suffix = ("kwargs",)
+    raise ConfitValidationError(
+        errors=[ErrorWrapper(err, loc_suffix)],
+        model=pydantic_func.model,
+        name=callee.__module__ + "." + callee.__qualname__,
+    )

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -528,5 +528,5 @@ def test_root_level_config_error():
 
 
 def test_simple_dump():
-    config = Config({"section": {"date": datetime.date.today()}})
+    config = Config({"section": {"date": datetime.date(2023, 8, 31)}})
     assert config.to_str() == '[section]\ndate = "2023-08-31"\n\n'


### PR DESCRIPTION
## Description

Adds possibility to register an object under multiple names with deprecation warnings.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
