### PR TITLE
Misc utils

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.5.1
+
+- Use context instead of func for set_seed to allow
+  ```python
+  with set_seed(42):
+      # do stuff
+      num = random.randint(0, 100)
+  ```
+- Add auto-reload plugin to work with confit wrapped functions in notebooks
+
 ## v0.5.0
 
 ### Added

--- a/confit/__init__.py
+++ b/confit/__init__.py
@@ -1,12 +1,15 @@
-from .cli import Cli  # noqa F401
-from .config import Config  # noqa F401
+from .cli import Cli
+from .config import Config
 from .registry import (
-    validate_arguments,  # noqa F401
-    Registry,  # noqa F401
-    get_default_registry,  # noqa F401
-    set_default_registry,  # noqa F401
-    RegistryCollection,  # noqa F401
-    VisibleDeprecationWarning,  # noqa F401
+    validate_arguments,
+    Registry,
+    get_default_registry,
+    set_default_registry,
+    RegistryCollection,
+    VisibleDeprecationWarning,
 )
+from .autoreload import autoreload_plugin
 
 __version__ = "0.5.0"
+
+autoreload_plugin()

--- a/confit/autoreload.py
+++ b/confit/autoreload.py
@@ -1,0 +1,40 @@
+"""
+Plugin to help IPython's autoreload magic reload functions wrapped with confit.
+"""
+
+import types
+
+
+def check_wrapped(a, b):
+    return (
+        isinstance(b, types.FunctionType)
+        and hasattr(a, "__wrapped__")
+        and isinstance(a.__wrapped__, types.FunctionType)
+    )
+
+
+def update_wrapped_function(old, new):
+    from IPython.extensions.autoreload import func_attrs
+
+    """Upgrade the code object of a function"""
+    new_func = new if not hasattr(new, "__wrapped__") else new.__wrapped__
+    for name in func_attrs:
+        try:
+            setattr(old.__wrapped__, name, getattr(new_func, name))
+        except (AttributeError, TypeError):
+            pass
+
+
+def autoreload_plugin():
+    try:
+        from IPython.extensions.autoreload import UPDATE_RULES
+    except ImportError:
+        return
+
+    UPDATE_RULES.insert(
+        0,
+        (
+            lambda a, b: check_wrapped(a, b),
+            update_wrapped_function,
+        ),
+    )

--- a/confit/utils/random.py
+++ b/confit/utils/random.py
@@ -1,41 +1,113 @@
 import random
+from collections import namedtuple
+from typing import Optional
+
+RandomGeneratorState = namedtuple(
+    "RandomGeneratorState", ["random", "torch", "numpy", "torch_cuda"]
+)
 
 
-def set_seed(seed):
+def get_random_generator_state(cuda=None):
     """
-    Set seed values for random generators.
-    If used as a context, restore the random state
-    used before entering the context.
-
+    Get the `torch`, `numpy` and `random` random generator state.
     Parameters
     ----------
-    seed: int
-        Value used as a seed.
     cuda: bool
         Saves the cuda random states too
+
+    Returns
+    -------
+    RandomGeneratorState
     """
-    # if seed is True:
-    #     seed = random.randint(1, 2**16)
+    torch_state = torch_cuda_state = numpy_state = None
+    random_state = random.getstate()
     try:
         import torch
 
-        cuda = torch.cuda.is_available()
-    except ImportError:
-        torch = None
-        cuda = False
+        torch_state = torch.random.get_rng_state()
+        if cuda or (cuda is None and torch.cuda.is_available()):  # pragma: no cover
+            torch_cuda_state = torch.cuda.get_rng_state_all()
+
+    except ImportError:  # pragma: no cover
+        pass
     try:
         import numpy
-    except ImportError:
-        numpy = None
 
-    if seed is True:
-        seed = random.randint(1, 2**16)
-    if seed is not None:
-        random.seed(seed)
-        if torch is not None:
-            torch.manual_seed(seed)
-        if cuda:  # pragma: no cover
-            torch.cuda.manual_seed(seed)
-            torch.cuda.manual_seed_all(seed)
-        if numpy is not None:
-            numpy.random.seed(seed)
+        numpy_state = numpy.random.get_state()
+    except ImportError:  # pragma: no cover
+        pass
+    return RandomGeneratorState(
+        random_state,
+        torch_state,
+        numpy_state,
+        torch_cuda_state,
+    )
+
+
+def set_random_generator_state(state):
+    """
+    Set the `torch`, `numpy` and `random` random generator state.
+    Parameters
+    ----------
+    state: RandomGeneratorState
+    """
+    random.setstate(state.random)
+    if state.torch is not None:
+        import torch
+
+        torch.random.set_rng_state(state.torch)
+        if (
+            state.torch_cuda is not None
+            and torch.cuda.is_available()
+            and len(state.torch_cuda) == torch.cuda.device_count()
+        ):  # pragma: no cover
+            torch.cuda.set_rng_state_all(state.torch_cuda)
+    if state.numpy is not None:
+        import numpy
+
+        numpy.random.set_state(state.numpy)
+
+
+class set_seed:
+    def __init__(self, seed, cuda: Optional[bool] = None):
+        """
+        Set seed values for random generators.
+        If used as a context, restore the random state
+        used before entering the context.
+
+        Parameters
+        ----------
+        seed: int
+            Value used as a seed.
+        cuda: bool
+            Saves the cuda random states too
+        """
+        # if seed is True:
+        #     seed = random.randint(1, 2**16)
+        seed = random.randint(1, 2**16) if seed is True else seed
+        self.state = get_random_generator_state(cuda)
+        if seed is not None:
+            random.seed(seed)
+            try:
+                import torch
+
+                torch.manual_seed(seed)
+                if cuda or (
+                    cuda is None and torch.cuda.is_available()
+                ):  # pragma: no cover
+                    torch.cuda.manual_seed(seed)
+                    torch.cuda.manual_seed_all(seed)
+            except ImportError:  # pragma: no cover
+                pass
+            try:
+                import numpy
+
+                numpy.random.seed(seed)
+            except ImportError:  # pragma: no cover
+                pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        set_random_generator_state(self.state)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dev = [
     "pytest>=7.1.1,<8.0",
     "pytest-cov>=4.0.0,<5.0",
     "rich",
+    "torch",
+    "numpy",
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ color = true
 omit-covered-files = false
 
 [tool.coverage.report]
+omit = [
+    "confit/autoreload.py",
+]
 exclude_also = [
     "def __repr__",
     "if __name__ == .__main__.:",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import random
+
+from confit.utils.random import set_seed
+
+
+def test_set_seed():
+    with set_seed(42):
+        number = random.randint(0, 100)
+
+    set_seed(43)
+
+    with set_seed(42):
+        assert random.randint(0, 100) == number


### PR DESCRIPTION
## Description

- use context instead of func for set_seed to allow
    ```python
    with set_seed(42):
        # do stuff
    ```

- add auto-reload plugin to work with confit wrapped functions in notebooks

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
