### PR TITLE
Escape path-like keys

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,22 @@
 # Changelog
 
+## v0.5.2
+
+### Changed
+
+- Keys with dots (or path-like keys in general) will be escaped when serializing a config
+```python
+{"section": {"deep.key": "ok"}}
+```
+will be serialized as
+```ini
+[section]
+'deep.key' = "ok"
+```
+
 ## v0.5.1
+
+### Added
 
 - Use context instead of func for set_seed to allow
   ```python

--- a/confit/__init__.py
+++ b/confit/__init__.py
@@ -10,6 +10,6 @@ from .registry import (
 )
 from .autoreload import autoreload_plugin
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 autoreload_plugin()

--- a/confit/config.py
+++ b/confit/config.py
@@ -96,7 +96,6 @@ class Config(dict):
                     else:
                         current = current[part]
                 current[path[-1]] = loads(v)
-                # current.update({k: loads(v) for k, v in parser.items(section)})
 
         if resolve:
             return config.resolve(registry=registry)
@@ -230,7 +229,9 @@ class Config(dict):
         parser.optionxform = str
         for section_name, section in prepared.items():
             parser.add_section(section_name)
-            parser[section_name].update({k: dumps(v) for k, v in section.items()})
+            parser[section_name].update(
+                {join_path((k,)): dumps(v) for k, v in section.items()}
+            )
         s = StringIO()
         parser.write(s)
         return s.getvalue()

--- a/confit/utils/collections.py
+++ b/confit/utils/collections.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Tuple, TypeVar, Union
 
 T = TypeVar("T")
 
+KEY_PART = r"(?:'([^']*)'|\"([^\"]*)\"|([^.]*))(?:[.]|$)"
+
 
 def join_path(path):
     """
@@ -17,7 +19,10 @@ def join_path(path):
     -------
     str
     """
-    return ".".join(repr(x) if not isinstance(x, str) or "." in x else x for x in path)
+    return ".".join(
+        repr(x) if not isinstance(x, str) or split_path(x.strip()) != (x,) else x
+        for x in path
+    )
 
 
 def split_path(path: str) -> Tuple[Union[int, str]]:
@@ -35,7 +40,7 @@ def split_path(path: str) -> Tuple[Union[int, str]]:
     """
     offset = 0
     result = []
-    for match in re.finditer(r"(?:'([^']*)'|\"([^\"]*)\"|([^.]*))(?:[.]|$)", str(path)):
+    for match in re.finditer(KEY_PART, str(path)):
         assert match.start() == offset, f"Malformed path: {path!r} in config"
         offset = match.end()
         part = next((g for g in match.groups() if g is not None))

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -520,6 +520,18 @@ def test_deep_key():
     assert config["section"]["deep"] == {"key": "ok"}
 
 
+def test_escaped_key():
+    config = Config.from_str(
+        """
+    [section]
+    "    escaped" = "ok"
+    """
+    )
+    assert config == {"section": {"    escaped": "ok"}}
+
+    assert config.to_str() == "[section]\n'    escaped' = \"ok\"\n\n"
+
+
 def test_root_level_config_error():
     with pytest.raises(Exception) as exc_info:
         Config({"ok": "ok"}).to_str()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Keys with dots (or path-like keys in general) will be escaped when serializing a config
```python
{"section": {"deep.key": "ok"}}
```
will be serialized as
```ini
[section]
'deep.key' = "ok"
```

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
