### PR TITLE
Forward deprecated fn signature

### DIFF
--- a/confit/__init__.py
+++ b/confit/__init__.py
@@ -10,6 +10,6 @@ from .registry import (
 )
 from .autoreload import autoreload_plugin
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 autoreload_plugin()

--- a/confit/registry.py
+++ b/confit/registry.py
@@ -446,6 +446,7 @@ class Registry(catalogue.Registry):
             for deprecated_name in deprecated:
 
                 def make_deprecated_fn(old):
+                    @wraps(fn)
                     def deprecated_fn(*args, **kwargs):
                         warnings.warn(
                             f'"{old}" is deprecated, please use "{name}" instead."',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Forwards function signature when accessing a callable via a deprecated registry name.
This is useful when `registry.get("deprecated-name")` is inspected.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
