### PR TITLE
v0.7.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - Aborting a script will now show the traceback
 
+### Fixed
+
+- Confit should no longer cause pydantic v1 deprecation warnings
+
 ## v0.6.0 (2024-09-13)
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.0 (2024-10-22)
+
+### Changed
+
+- Aborting a script will now show the traceback
+
 ## v0.6.0 (2024-09-13)
 
 ### Fixed

--- a/confit/__init__.py
+++ b/confit/__init__.py
@@ -9,4 +9,4 @@ from .registry import (
     VisibleDeprecationWarning,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/confit/cli.py
+++ b/confit/cli.py
@@ -168,6 +168,8 @@ class Cli(Typer):
                         print("Validation error:", file=sys.stderr, end=" ")
                         print(str(e), file=sys.stderr)
                     sys.exit(1)
+                except KeyboardInterrupt as e:  # pragma: no cover
+                    raise Exception("Interrupted by user") from e
 
             return validated
 

--- a/confit/errors.py
+++ b/confit/errors.py
@@ -28,6 +28,7 @@ from confit.utils.collections import join_path
 from confit.utils.xjson import Reference
 
 Loc = Tuple[Union[int, str]]
+PYDANTIC_V1 = pydantic.VERSION.split(".")[0] == "1"
 
 
 class MissingReference(Exception):
@@ -243,11 +244,11 @@ def patch_errors(
                 #     field_model.vd.model, pydantic.BaseModel
                 # ):
                 #     field_model = field_model.vd.model
-                if hasattr(field_model, "model_fields"):
-                    field_model = field_model.model_fields[part]
-                else:
+                if PYDANTIC_V1:
                     field_model = field_model.__fields__[part]
-                if hasattr(field_model, "type_"):
+                else:
+                    field_model = field_model.model_fields[part]
+                if PYDANTIC_V1:
                     field_model = field_model.type_
                 else:
                     field_model = field_model.annotation

--- a/tests/test_as_list.py
+++ b/tests/test_as_list.py
@@ -1,22 +1,48 @@
-from typing import Any, Generic, List, TypeVar
+from dataclasses import is_dataclass
+from typing import Generic, List, TypeVar
 
 import pydantic
 import pytest
+from pydantic import BaseModel
+from typing_extensions import is_typeddict
 
 from confit import validate_arguments
 from confit.errors import ConfitValidationError, patch_errors
 
 T = TypeVar("T")
+if pydantic.VERSION < "2":
+
+    def cast(type_, obj):
+        class Model(pydantic.BaseModel):
+            __root__: type_
+
+            class Config:
+                arbitrary_types_allowed = True
+
+        return Model(__root__=obj).__root__
+
+else:
+    from pydantic.type_adapter import ConfigDict, TypeAdapter
+    from pydantic_core import core_schema
+
+    def make_type_adapter(type_):
+        config = None
+        if not issubclass(type, BaseModel) or is_dataclass(type) or is_typeddict(type):
+            config = ConfigDict(arbitrary_types_allowed=True)
+        return TypeAdapter(type_, config=config)
+
+    def cast(type_, obj):
+        return make_type_adapter(type_).validate_python(obj)
 
 
 class MetaAsList(type):
     def __init__(cls, name, bases, dct):
         super().__init__(name, bases, dct)
-        cls.item = Any
+        cls.type_ = List
 
     def __getitem__(self, item):
         new_type = MetaAsList(self.__name__, (self,), {})
-        new_type.item = item
+        new_type.type_ = List[item]
         return new_type
 
     def validate(cls, value, config=None):
@@ -25,7 +51,7 @@ class MetaAsList(type):
         if not isinstance(value, list):
             value = [value]
         try:
-            return pydantic.parse_obj_as(List[cls.item], value)
+            return cast(cls.type_, value)
         except pydantic.ValidationError as e:
             e = patch_errors(e, drop_names=("__root__",))
             e.model = cls
@@ -33,6 +59,9 @@ class MetaAsList(type):
 
     def __get_validators__(cls):
         yield cls.validate
+
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return core_schema.no_info_plain_validator_function(cls.validate)
 
 
 class AsList(Generic[T], metaclass=MetaAsList):
@@ -52,3 +81,27 @@ def test_as_list():
     assert (
         "1 validation error for test_as_list.test_as_list.<locals>.func()\n" "-> a.0\n"
     ) in str(e.value)
+
+
+class CustomMeta(type):
+    def __getattr__(self, item):
+        raise AttributeError(item)
+
+    def __dir__(self):
+        return super().__dir__()
+
+
+class Custom:
+    def __init__(self, value: int):
+        self.value = value
+
+
+def test_as_list_custom():
+    @validate_arguments
+    def func(a: AsList[Custom]):
+        return [x.value for x in a]
+
+    assert func(Custom(4)) == [4]
+
+    with pytest.raises(ConfitValidationError):
+        func({"data": "ok"})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Changed

- Aborting a script will now show the traceback

### Fixed

- Confit should no longer cause pydantic v1 deprecation warnings

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
