### PR TITLE
Fix/issue 26 : YAML Parsing for Large Config Files

### DIFF
--- a/confit/config.py
+++ b/confit/config.py
@@ -145,7 +145,9 @@ class Config(dict):
         class ConfitYamlLoader(yaml.SafeLoader):
             def construct_object(self, x, deep=False):
                 if isinstance(x, yaml.ScalarNode):
-                    return loads(self.buffer[x.start_mark.index : x.end_mark.index])
+                    if x.style == '"' or x.style == "'":
+                        return loads(x.style + x.value + x.style)
+                    return loads(x.value)
                 return super().construct_object(x, deep)
 
         stream = StringIO(s)

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -685,3 +685,34 @@ params:
 """
     ).resolve(registry=registry)
     assert config["params"]["c"] == 12
+
+
+def test_very_long_yaml_config():
+    config = Config.from_yaml_str(
+        """\
+        a: {}
+        """.format(
+            "x" * 4200
+        )
+    ).resolve(registry=registry)
+    assert config == {"a": "x" * 4200}
+
+
+def test_escaped_string():
+    config = Config.from_yaml_str(
+        """
+test:
+    a: "1"
+section:
+    num: 1
+    escaped_num: "1"
+    real_ref: ${test.a}
+    escaped_broken_ref: "${test.a"
+    escaped_ref: "${test.a}"
+"""
+    ).resolve(registry=registry)
+    assert config["section"]["num"] == 1
+    assert config["section"]["escaped_num"] == "1"
+    assert config["section"]["real_ref"] == "1"
+    assert config["section"]["escaped_broken_ref"] == "${test.a"
+    assert config["section"]["escaped_ref"] == "${test.a}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
## Fix YAML Parsing for Large Config Files

## Description

**Support for YAML config files exceeding 4096 characters**:  
Previously, the library failed to handle YAML files larger than 4096 characters due to limitations in how values were parsed in `ConfitYamlLoader`. This has been resolved by modifying the `construct_object` method to use `x.value`, ensuring robust parsing regardless of file size.

### Key Changes:
- Updated `ConfitYamlLoader` to use `x.value` for parsing scalar nodes.
- Added `test_very_long_yaml_config` and `test_escaped_string` unit tests.


## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
