### PR TITLE
Fix: escape tabs and newline when serializing to a config file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - Support interpolated seed in the config file (as a reminder, the seed is treated specifically by confit to initialize random generators **before** any object is resolved)
 - Support if/else expressions in interpolation, and only resolve the relevant branch
+- Allow larger than 4096 bytes config files
+- Escape tabs and newline when serializing to a config file
 
 ## v0.7.2 (2024-11-23)
 

--- a/confit/config.py
+++ b/confit/config.py
@@ -313,8 +313,7 @@ class Config(dict):
 
             def represent_str(self, data):
                 node = super().represent_scalar("tag:yaml.org,2002:str", data)
-                if set(",'\"{}[]$") & set(data):
-                    # node.value = dumps(data)
+                if set(",'\"{}[]$\n\t") & set(data):
                     node.style = "'" if data.count('"') > data.count("'") else '"'
                 return node
 

--- a/confit/utils/xjson.py
+++ b/confit/utils/xjson.py
@@ -165,7 +165,8 @@ def _encode_str(s):
     """Return an ASCII-only JSON representation of a Python string"""
     r = repr(s)
     if s.count('"') <= s.count("'") and r.startswith("'"):
-        r = '"' + s.replace('"', '\\"').replace("\\'", "'") + '"'
+        r = r[1:-1]
+        r = '"' + r.replace('"', '\\"').replace("\\'", "'") + '"'
     return r
 
 
@@ -294,4 +295,5 @@ def dumps(o: Any):
     -------
     str
     """
-    return "".join(_make_iterencode()(o))
+    res = "".join(_make_iterencode()(o))
+    return res

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -716,3 +716,28 @@ section:
     assert config["section"]["real_ref"] == "1"
     assert config["section"]["escaped_broken_ref"] == "${test.a"
     assert config["section"]["escaped_ref"] == "${test.a}"
+
+
+def test_newline_serialization():
+    config = Config(
+        {
+            "section": {
+                "string": "\tok\nok",
+            }
+        }
+    )
+    assert (
+        config.to_yaml_str()
+        == """\
+section:
+    string: "\\tok\\nok"
+"""
+    )
+    assert (
+        config.to_cfg_str()
+        == """\
+[section]
+string = "\\tok\\nok"
+
+"""
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Setting a "\n" value in a config file and serializing the new config led to weird formatting e.g.
```
section:
  regex: '

    +'
```

Now its:
```
section:
    regex: '\n+'
```

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
