### PR TITLE
chore: bump version to 0.7.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.7.4 (2025-01-15)
 
 - Allow larger than 4096 bytes config files
 - Escape tabs and newline when serializing to a config file

--- a/confit/__init__.py
+++ b/confit/__init__.py
@@ -9,4 +9,4 @@ from .registry import (
     VisibleDeprecationWarning,
 )
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

- Allow larger than 4096 bytes config files
- Escape tabs and newline when serializing to a config file
- Fix an infinite loop that occured when resolving a reference to a field with a null value

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
