### PR TITLE
fix: improve draft implementation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-- Deprecate `auto_draft_in_config`, in favor of explicitly using
+- Drop `auto_draft_in_config`, in favor of explicitly using
   ```
   @registry: myname !draft
   ```
   to define a draft object
-- :boom: Even if a `MyClass.draft(...)` instantiation contains all required parameter, it will still return a draft. `draft.instantiate` must be called to instantiate the actual object.
+- :boom: Even if a `MyClass.draft(...)` instantiation contains all required parameter, it will now still return a draft. `draft.instantiate` must be called to instantiate the actual object.
+- Support `isinstance(obj, Draft)` for Draft instances
 
 ## v0.9.0 (2025-05-15)
 

--- a/confit/draft.py
+++ b/confit/draft.py
@@ -126,6 +126,11 @@ class MetaDraft(type):
     def __repr__(self):
         return f"Draft[{self.type_.__qualname__}]"
 
+    def __instancecheck__(cls, obj):
+        if isinstance(type(obj), MetaDraft):
+            return obj.type_ == cls.type_ or cls.type_ is Any
+        return False
+
 
 T = TypeVar("T")
 
@@ -166,7 +171,8 @@ class Draft(Generic[T], metaclass=MetaDraft):
 
         # Order matters: priority is given to the kwargs provided
         # by the user, so most likely when the Partial is instantiated
-        return self._func(**{**kwargs, **self._kwargs})
+        res = self._func(**{**kwargs, **self._kwargs})
+        return res
 
     def _raise_draft_error(self):
         raise TypeError(


### PR DESCRIPTION
Completes the `explicit-draft` PR:
- improve isinstance(x, Draft)
- removes completely the `auto_draft_in_config` option