### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.10.0
 
 - Deprecate `auto_draft_in_config`, in favor of explicitly using
   ```

--- a/confit/__init__.py
+++ b/confit/__init__.py
@@ -11,4 +11,4 @@ from .registry import (
 from .typing import Validatable, cast
 from .draft import Draft
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

- Deprecate `auto_draft_in_config`, in favor of explicitly using
  ```
  @registry: myname !draft
  ```
  to define a draft object
- :boom: Even if a `MyClass.draft(...)` instantiation contains all required parameter, it will still return a draft. `draft.instantiate` must be called to instantiate the actual object.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
