### PR TITLE
fix: warn instead of fail when suspecting malformed configs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.3 (2025-01-19)
+
+- Don't fail but warn, when we suspect that un unquoted string might actually be an object in config files.
+
 ## v0.10.2 (2025-12-11)
 
 - Confit should not complain anymore when given multiline strings

--- a/confit/config.py
+++ b/confit/config.py
@@ -14,7 +14,6 @@ from confit.draft import Draft
 from confit.errors import (
     ConfitValidationError,
     CyclicReferenceError,
-    ErrorWrapper,
     MissingReference,
     patch_errors,
     remove_lib_from_traceback,
@@ -421,9 +420,9 @@ class Config(dict):
                     for key, value in resolved.items()
                     if isinstance(key, str) and key.startswith("@")
                 ]
-                assert (
-                    len(registries) <= 1
-                ), f"Cannot resolve using multiple registries at {'.'.join(loc)}"
+                assert len(registries) <= 1, (
+                    f"Cannot resolve using multiple registries at {'.'.join(loc)}"
+                )
 
                 if len(registries) == 1:
                     raw_key, value, registry_value = registries[0]
@@ -433,7 +432,7 @@ class Config(dict):
                     value = value.strip()
                     is_draft = value.endswith("!draft")
                     if is_draft:
-                        value = value[:-len("!draft")].strip()
+                        value = value[: -len("!draft")].strip()
                     fn = registry_value.get(value)
                     try:
                         if is_draft:

--- a/confit/config.py
+++ b/confit/config.py
@@ -120,11 +120,7 @@ class Config(dict):
             current.clear()
             errors = []
             for k, v in parser.items(section):
-                parsed_k = loads(k)
-                try:
-                    current[parsed_k] = loads(v)
-                except ValueError as e:
-                    errors.append(ErrorWrapper(e, loc=parsed_k))
+                current[loads(k)] = loads(v)
 
             if errors:
                 raise ConfitValidationError(errors=errors)

--- a/confit/utils/xjson.py
+++ b/confit/utils/xjson.py
@@ -254,12 +254,6 @@ def _make_iterencode(
     return _iterencode
 
 
-class MalformedValueError(ValueError):
-    def __init__(self, value: str):
-        self.value = value
-        super().__init__(f"Malformed value: {value!r}")
-
-
 def loads(s: str):
     """
     Load an extended JSON string into a python object.

--- a/confit/utils/xjson.py
+++ b/confit/utils/xjson.py
@@ -1,6 +1,6 @@
 import ast
-from typing import Any, Callable
 import warnings
+from typing import Any, Callable
 
 from lark import Lark, Transformer, Tree
 

--- a/confit/utils/xjson.py
+++ b/confit/utils/xjson.py
@@ -1,5 +1,6 @@
 import ast
 from typing import Any, Callable
+import warnings
 
 from lark import Lark, Transformer, Tree
 
@@ -280,7 +281,10 @@ def loads(s: str):
         # Fail if we suspect that it is a malformed object
         # (e.g. has ', ", {, }, [, ] in it)
         if set(s) & set(",'\"{}[]$"):
-            raise MalformedValueError(s)
+            warnings.warn(
+                f"Some values may be malformed JSON objects. Got: {s!r}",
+                UserWarning,
+            )
         return s
 
 

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -568,8 +568,8 @@ def test_warn_if_suspected_json_malformation():
 
     assert len(record) == 2
     assert [str(w.message) for w in record] == [
-        f"Some values may be malformed JSON objects. Got: {\"'ok\"!r}",
-        f"Some values may be malformed JSON objects. Got: {\"'ok']\"!r}",
+        f"Some values may be malformed JSON objects. Got: \"'ok\"",
+        f"Some values may be malformed JSON objects. Got: \"'ok']\"",
     ]
 
     assert config == {"section": {"string": "'ok", "list": "'ok']"}}

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -556,22 +556,23 @@ def test_list_interpolation():
     assert config["section"]["b"] == ["foo", "bar", "baz"]
 
 
-def test_fail_if_suspected_json_malformation():
-    with pytest.raises(ConfitValidationError) as exc_info:
-        Config.from_str(
+def test_warn_if_suspected_json_malformation():
+    with pytest.warns(UserWarning) as record:
+        config = Config.from_str(
             """
         [section]
         string = 'ok
         list = 'ok']
         """
         )
-    assert str(exc_info.value) == (
-        "2 validation errors\n"
-        "-> string\n"
-        '   Malformed value: "\'ok"\n'
-        "-> list\n"
-        "   Malformed value: \"'ok']\""
-    )
+
+    assert len(record) == 2
+    assert [str(w.message) for w in record] == [
+        f"Some values may be malformed JSON objects. Got: {"'ok"!r}",
+        f"Some values may be malformed JSON objects. Got: {"'ok']"!r}",
+    ]
+
+    assert config == {"section": {"string": "'ok", "list": "'ok']"}}
 
 
 def test_string():

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -568,8 +568,8 @@ def test_warn_if_suspected_json_malformation():
 
     assert len(record) == 2
     assert [str(w.message) for w in record] == [
-        f"Some values may be malformed JSON objects. Got: \"'ok\"",
-        f"Some values may be malformed JSON objects. Got: \"'ok']\"",
+        'Some values may be malformed JSON objects. Got: "\'ok"',
+        "Some values may be malformed JSON objects. Got: \"'ok']\"",
     ]
 
     assert config == {"section": {"string": "'ok", "list": "'ok']"}}

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -568,8 +568,8 @@ def test_warn_if_suspected_json_malformation():
 
     assert len(record) == 2
     assert [str(w.message) for w in record] == [
-        f"Some values may be malformed JSON objects. Got: {"'ok"!r}",
-        f"Some values may be malformed JSON objects. Got: {"'ok']"!r}",
+        f"Some values may be malformed JSON objects. Got: {\"'ok\"!r}",
+        f"Some values may be malformed JSON objects. Got: {\"'ok']\"!r}",
     ]
 
     assert config == {"section": {"string": "'ok", "list": "'ok']"}}


### PR DESCRIPTION
- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
