### PR TITLE
Improved CLI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          source .venv/bin/activate 
+          source .venv/bin/activate
           uv pip install -e . --group dev
 
       - name: Test with Pytest on Python ${{ matrix.python-version }}
@@ -57,9 +57,9 @@ jobs:
       - name: Test with Pytest on Python ${{ matrix.python-version }} with pydantic v1
         run: |
           source .venv/bin/activate
-          uv pip install pydantic==1.10.7
+          uv pip install "pydantic<2"
           coverage run -m pytest
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
@@ -93,7 +93,7 @@ jobs:
     - name: Install dependencies
       run: |
         uv venv
-        source .venv/bin/activate 
+        source .venv/bin/activate
         uv pip install -e . --group docs --group dev
     - name: Build documentation
       run: |
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ class BigModel:
 # you can use @confit.validate_arguments instead if you don't plan on using the CLI
 + @app.command(name="script", registry=registry)
 def func(modelA: BigModel, modelB: BigModel, seed: int = 42):
+    """
+    Display the configured model dates.
+
+    Parameters
+    ----------
+    modelA : BigModel
+        The first model whose date is displayed.
+    modelB : BigModel
+        The second model whose date is displayed.
+    seed : int
+        Random seed.
+    """
     assert modelA.submodel is modelB.submodel
     print("modelA.date:", modelA.date.strftime("%B %-d, %Y"))
     print("modelB.date:", modelB.date.strftime("%B %-d, %Y"))
@@ -98,6 +110,35 @@ python script.py --config config.cfg --seed 43
 ```
 
 </div>
+
+The generated CLI also has a readable help message based on the function
+signature and docstrings:
+
+```bash
+python script.py --help
+```
+
+```text
+Display the configured model dates.
+
+Parameters
+----------
+  --config <Path>
+    Load a config file to fill in the following params. Can be repeated.
+
+  --modelA <BigModel>
+    The first model whose date is displayed.
+
+    --modelA.<field> VALUE
+
+  --modelB <BigModel>
+    The second model whose date is displayed.
+
+    --modelB.<field> VALUE
+
+  --seed <int> (default: 42)
+    Random seed.
+```
 
 You can still call the `function` method from your code, but now also benefit from
 argument validation !

--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,6 @@
 - Fix indexing: `Config.from_yaml_str(...)[key]` is now a Config object if it's a mapping
 - Drop typer and click, and handle the CLI ourselves, with better rendering for complex functions
 - Fix, correctly locate param error in error log when using Draft objects
-
-## v0.10.3 (2025-01-19)
-
 - Don't fail but warn, when we suspect that un unquoted string might actually be an object in config files.
 - Improved typing checks for drafts: we forbid string type hints, as we cannot validate against them
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix indexing: `Config.from_yaml_str(...)[key]` is now a Config object if it's a mapping
+- Drop typer and click, and handle the CLI ourselves, with better rendering for complex functions
 
 ## v0.10.3 (2025-01-19)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix indexing: `Config.from_yaml_str(...)[key]` is now a Config object if it's a mapping
+
 ## v0.10.3 (2025-01-19)
 
 - Don't fail but warn, when we suspect that un unquoted string might actually be an object in config files.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - Fix indexing: `Config.from_yaml_str(...)[key]` is now a Config object if it's a mapping
 - Drop typer and click, and handle the CLI ourselves, with better rendering for complex functions
+- Fix, correctly locate param error in error log when using Draft objects
 
 ## v0.10.3 (2025-01-19)
 

--- a/confit/cli.py
+++ b/confit/cli.py
@@ -1,11 +1,21 @@
+import importlib
 import inspect
+import re
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, Union
-
-from typer import Context, Typer, colors, secho
-from typer.core import TyperCommand
-from typer.models import CommandFunctionType, Default
+from types import UnionType
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from .config import Config, merge_from_disk
 from .errors import ConfitValidationError, LegacyValidationError, patch_errors
@@ -14,11 +24,14 @@ from .utils.random import set_seed
 from .utils.settings import is_debug
 from .utils.xjson import loads
 
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
 
 def parse_overrides(args: List[str]) -> Dict[str, Any]:
     """
     Parse the overrides from the command line into a dictionary
-    of key-value pairs.
+    of key value pairs.
 
     Parameters
     ----------
@@ -34,37 +47,42 @@ def parse_overrides(args: List[str]) -> Dict[str, Any]:
     while args:
         opt = args.pop(0)
         err = f"Invalid config override '{opt}'"
-        if opt.startswith("--"):  # new argument
+        if opt.startswith("--"):
             opt = opt.replace("--", "")
-            if "=" in opt:  # we have --opt=value
+            if "=" in opt:
                 opt, value = opt.split("=", 1)
             else:
-                if not args or args[0].startswith("--"):  # flag with no value
+                if not args or args[0].startswith("--"):
                     value = "true"
                 else:
                     value = args.pop(0)
             opt = opt.replace("-", "_")
             result[opt] = loads(value)
         else:
-            secho(f"{err}: doesn't support shorthands", fg=colors.RED)
+            print(f"{err}: doesn't support shorthands")
             exit(1)
     return result
 
 
-class Cli(Typer):
+class Cli:
     """
-    Custom Typer object that:
+    Command line application for Confit commands that:
 
     - validates a command parameters before executing it
     - accepts a configuration file describing the parameters
     - automatically instantiates parameters given a dictionary when type hinted
     """
 
+    def __init__(self, *args: Any, **kwargs: Any):
+        self.commands = {}
+
+    # User code calls this as a decorator to register one command.
+    # The stored metadata is used by main.
     def command(  # noqa
         self,
         name,
         *,
-        cls: Optional[Type[TyperCommand]] = None,
+        cls: Optional[Type] = None,
         context_settings: Optional[Dict[Any, Any]] = None,
         help: Optional[str] = None,
         epilog: Optional[str] = None,
@@ -74,124 +92,478 @@ class Cli(Typer):
         no_args_is_help: bool = False,
         hidden: bool = False,
         deprecated: bool = False,
-        # Rich settings
-        rich_help_panel: Union[str, None] = Default(None),
+        rich_help_panel: Union[str, None] = None,
         registry: Any = None,
         default_config: Optional[Config] = None,
         merge_with_default_config: bool = False,
-    ) -> Callable[[CommandFunctionType], CommandFunctionType]:
-        typer_command = super().command(
-            name=name,
-            cls=cls,
-            help=help,
-            epilog=epilog,
-            short_help=short_help,
-            options_metavar=options_metavar,
-            add_help_option=add_help_option,
-            no_args_is_help=no_args_is_help,
-            hidden=hidden,
-            deprecated=deprecated,
-            rich_help_panel=rich_help_panel,
-            context_settings={
-                **(context_settings or {}),
-                "ignore_unknown_options": True,
-                "allow_extra_args": True,
-            },
-        )
-
+    ) -> Callable[[Callable], Callable]:
         def wrapper(fn):
             validated = validate_arguments(fn)
-
-            @typer_command
-            def command(ctx: Context, config: Optional[List[Path]] = None):
-                config_path = config
-
-                has_meta = _fn_has_meta(fn)
-                if config_path:
-                    config, name_from_file = merge_from_disk(config_path)
-                elif default_config is not None:
-                    config = default_config
-                else:
-                    config = Config({name: {}})
-                if default_config is not None and merge_with_default_config:
-                    config = Config(default_config).merge(config)
-                model_fields = (
-                    validated.model.model_fields
-                    if hasattr(validated.model, "model_fields")
-                    else validated.model.__fields__
-                )
-                for k, v in parse_overrides(ctx.args).items():
-                    if "." not in k:
-                        parts = (name, k)
-                    else:
-                        parts = k.split(".")
-                        if parts[0] in model_fields and parts[0] not in config:
-                            parts = (name, *parts)
-                    current = config
-                    if parts[0] not in current:
-                        raise Exception(
-                            f"{k} does not match any existing section in config"
-                        )
-                    for part in parts[:-1]:
-                        current = current.setdefault(part, Config())
-                    current[parts[-1]] = v
-                try:
-                    default_seed = model_fields.get("seed")
-                    if default_seed is not None:
-                        default_seed = default_seed.get_default()
-                    seed = Config.resolve(
-                        config.get(name, {}).get("seed", default_seed),
-                        registry=registry,
-                        root=config,
-                    )
-                    if seed is not None:
-                        set_seed(seed)
-                    resolved_config = Config(config[name]).resolve(
-                        registry=registry, root=config
-                    )
-                    if has_meta:
-                        config_meta = dict(
-                            config_path=config_path,
-                            resolved_config=resolved_config,
-                            unresolved_config=config,
-                        )
-                        return validated(
-                            **resolved_config,
-                            config_meta=config_meta,
-                        )
-                    else:
-                        return validated(**resolved_config)
-                except (LegacyValidationError, ConfitValidationError) as e:
-                    e.raw_errors = patch_errors(
-                        e.raw_errors,
-                        (name,),
-                    )
-                    if is_debug() or e.__cause__ is not None:
-                        raise e
-
-                    def cprint(*args, style=None, **kw):  # pragma: no cover
-                        return print(*args, **kw)
-
-                    try:  # pragma: no cover
-                        try:
-                            from typer.main import console_stderr
-                        except ImportError:
-                            import rich
-
-                            console_stderr = rich.console.Console(stderr=True)
-                        cprint = console_stderr.print
-                    except Exception:  # pragma: no cover
-                        pass
-                    cprint("Validation error:", style="red", end=" ")
-                    cprint(str(e))
-                    sys.exit(1)
-                except KeyboardInterrupt as e:  # pragma: no cover
-                    raise Exception("Interrupted by user") from e
-
+            # main will read this record to resolve config values and call the function.
+            self.commands[name] = {
+                "fn": fn,
+                "validated": validated,
+                "help": help,
+                "registry": registry,
+                "default_config": default_config,
+                "merge_with_default_config": merge_with_default_config,
+            }
             return validated
 
         return wrapper
 
+    def __call__(self, args: Optional[List[str]] = None):
+        return self.main(args=args)
 
-def _fn_has_meta(fn):
-    return "config_meta" in inspect.signature(fn).parameters
+    # Script entry points call this to handle argv.
+    # It either prints help or executes the selected command.
+    def main(self, args: Optional[List[str]] = None):
+        args = list(sys.argv[1:] if args is None else args)
+        commands_help = "\n".join(
+            ["Commands:", *(f"  {name}" for name in self.commands)]
+        )
+
+        # The command name is optional for single command apps.
+        # args is left with only config paths and overrides.
+        if args and args[0] in self.commands:
+            name = args.pop(0)
+            command = self.commands[name]
+        elif len(self.commands) == 1:
+            name = next(iter(self.commands))
+            command = self.commands[name]
+        elif args and args[0] in {"--help", "-h"}:
+            print(commands_help)
+            raise SystemExit(0)
+        else:
+            raise Exception("Missing command")
+
+        if not args and len(self.commands) > 1:
+            print(commands_help)
+            raise SystemExit(0)
+
+        if any(arg in {"--help", "-h"} for arg in args):
+            print(add_config_overrides_help(command["help"], command["fn"]))
+            raise SystemExit(0)
+
+        # config_path is passed to merge_from_disk.
+        # overrides is passed to parse_overrides and merged under the command section.
+        config_path = []
+        overrides = []
+        while args:
+            arg = args.pop(0)
+            if arg == "--config":
+                if not args:
+                    raise Exception("--config expects a path")
+                config_path.append(Path(args.pop(0)))
+            elif arg.startswith("--config="):
+                config_path.append(Path(arg.split("=", 1)[1]))
+            else:
+                overrides.append(arg)
+
+        return self.run_command(name, command, config_path or None, overrides)
+
+    # main calls this with paths and overrides parsed from argv.
+    # The returned value is the wrapped command result.
+    def run_command(self, name, command, config_path, overrides):
+        fn = command["fn"]
+        validated = command["validated"]
+        registry = command["registry"]
+        default_config = command["default_config"]
+        merge_with_default_config = command["merge_with_default_config"]
+
+        if config_path:
+            config, _name_from_file = merge_from_disk(config_path)
+        elif default_config is not None:
+            config = default_config
+        else:
+            config = Config({name: {}})
+        if default_config is not None and merge_with_default_config:
+            config = Config(default_config).merge(config)
+
+        # model_fields tells whether dotted overrides start at the command section.
+        # For example model.date becomes script.model.date when model is a parameter.
+        model_fields = (
+            validated.model.model_fields
+            if hasattr(validated.model, "model_fields")
+            else validated.model.__fields__
+        )
+        for key, value in parse_overrides(overrides).items():
+            if "." not in key:
+                parts = (name, key)
+            else:
+                parts = key.split(".")
+                if parts[0] in model_fields and parts[0] not in config:
+                    parts = (name, *parts)
+            current = config
+            if parts[0] not in current:
+                raise Exception(f"{key} does not match any existing section in config")
+            for part in parts[:-1]:
+                current = current.setdefault(part, Config())
+            current[parts[-1]] = value
+
+        try:
+            default_seed = model_fields.get("seed")
+            if default_seed is not None:
+                default_seed = default_seed.get_default()
+            seed = Config.resolve(
+                config.get(name, {}).get("seed", default_seed),
+                registry=registry,
+                root=config,
+            )
+            if seed is not None:
+                set_seed(seed)
+            resolved_config = Config(config[name]).resolve(
+                registry=registry,
+                root=config,
+            )
+            if "config_meta" in inspect.signature(fn).parameters:
+                config_meta = dict(
+                    config_path=config_path,
+                    resolved_config=resolved_config,
+                    unresolved_config=config,
+                )
+                return validated(**resolved_config, config_meta=config_meta)
+            return validated(**resolved_config)
+        except (LegacyValidationError, ConfitValidationError) as e:
+            e.raw_errors = patch_errors(e.raw_errors, (name,))
+            if is_debug() or e.__cause__ is not None:
+                raise e
+            print("Validation error:", str(e))
+            sys.exit(1)
+        except KeyboardInterrupt as e:  # pragma: no cover
+            raise Exception("Interrupted by user") from e
+
+
+# command stores this plain text and main prints it for help requests.
+def add_config_overrides_help(help_text, fn):
+    signature = inspect.signature(fn)
+    params = {
+        param.name: param
+        for param in signature.parameters.values()
+        if param.name != "config_meta"
+        and param.kind
+        not in {
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        }
+    }
+    base_help = help_text if help_text is not None else inspect.getdoc(fn)
+    if base_help:
+        return format_cli_help_text(base_help, params)
+
+    lines = [
+        "Parameters:",
+        "----------",
+        format_config_parameter(),
+    ]
+    for param in params.values():
+        lines.append("")
+        lines.append(format_cli_parameter(param))
+        if annotation_allows_fields(param.annotation):
+            lines.append(f"    {BOLD}--{param.name}.<field>{RESET} VALUE")
+
+    return "\n".join(lines)
+
+
+# The top level help builder calls this to turn a docstring into option help.
+# prefix is used when rendering nested object fields like scorer batch size.
+def format_cli_help_text(
+    help_text,
+    params,
+    prefix=None,
+    include_parameters_heading=True,
+):
+    from griffe import Docstring, DocstringSectionKind, Parser
+
+    result = []
+    help_text = re.sub(
+        r"^(\s*)([A-Za-z_]\w*)\s*:\s+(.+)$",
+        r"\1\2 : \3",
+        help_text,
+        flags=re.MULTILINE,
+    )
+    for section in Docstring(help_text, lineno=1).parse(
+        Parser.numpy,
+        warnings=False,
+        warn_unknown_params=False,
+        warn_missing_types=False,
+    ):
+        if section.kind is DocstringSectionKind.text:
+            result.extend(
+                sanitize_help_lines(
+                    section.value.splitlines(),
+                    base_indent=0,
+                    prefix=prefix,
+                )
+            )
+            continue
+        if section.kind is DocstringSectionKind.parameters:
+            if result and result[-1]:
+                result.append("")
+            param_lines = []
+            for doc_param in section.value:
+                param = params.get(doc_param.name)
+                if param is None:
+                    continue
+
+                if param_lines:
+                    param_lines.append("")
+
+                # param_lines is the rendered help for this Parameters section.
+                # Nested object docs use prefix and omit constructor defaults.
+                param_lines.append(
+                    format_cli_parameter(
+                        param,
+                        annotation=doc_param.annotation,
+                        prefix=prefix,
+                        include_default=prefix is None,
+                    )
+                )
+                param_lines.extend(
+                    sanitize_help_lines(
+                        doc_param.description.splitlines(),
+                        base_indent=4,
+                        prefix=parameter_option_path(param, prefix),
+                    )
+                )
+                if (
+                    prefix is None
+                    and annotation_allows_fields(param.annotation)
+                    and not re.search(
+                        r"^\s*:::\s+\S+",
+                        doc_param.description,
+                        flags=re.MULTILINE,
+                    )
+                ):
+                    # Use a generic field hint only when no linked object docs exist.
+                    # Linked object docs produce concrete nested fields instead.
+                    param_lines.append("")
+                    param_lines.append(f"    {BOLD}--{param.name}.<field>{RESET} VALUE")
+            if include_parameters_heading:
+                result.extend(
+                    [
+                        "Parameters",
+                        "----------",
+                        format_config_parameter(),
+                        "",
+                        *param_lines,
+                    ]
+                )
+            else:
+                result.extend(param_lines)
+            continue
+        if section.kind in {
+            DocstringSectionKind.returns,
+            DocstringSectionKind.yields,
+        }:
+            continue
+
+    return "\n".join(result)
+
+
+def format_config_parameter():
+    return "\n".join(
+        [
+            f"  {BOLD}--config{RESET} <Path>",
+            "    Load a config file to fill in the following params. Can be repeated.",
+        ]
+    )
+
+
+# The docstring renderer calls this for each option line.
+# prefix is the parent path for nested options.
+def format_cli_parameter(param, annotation=None, prefix=None, include_default=True):
+    option = parameter_option_path(param, prefix)
+    annotation = (
+        "Any"
+        if param.kind is inspect.Parameter.VAR_KEYWORD
+        else annotation or format_annotation(param.annotation)
+    )
+    default = (
+        "required"
+        if param.default is inspect.Signature.empty
+        else f"default: {param.default!r}"
+    )
+    suffix = "" if not include_default or default == "required" else f" ({default})"
+    return f"  {BOLD}--{option}{RESET} <{annotation}>{suffix}"
+
+
+# Option line rendering and nested help expansion use this to join option paths.
+# Var keyword parameters become field placeholders.
+def parameter_option_path(param, prefix=None):
+    name = param.name
+    if param.kind is inspect.Parameter.VAR_KEYWORD:
+        name = f"{name}.<field>"
+    return name if prefix is None else f"{prefix}.{name}"
+
+
+# Option line rendering uses this to display compact type names in help output.
+def format_annotation(annotation):
+    if annotation is inspect.Signature.empty:
+        return "Any"
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin in {Union, UnionType}:
+        non_none_args = tuple(arg for arg in args if arg is not type(None))
+        if len(non_none_args) == 1 and len(non_none_args) != len(args):
+            return f"Optional[{format_annotation(non_none_args[0])}]"
+        return "Union[{}]".format(
+            ", ".join(format_annotation(arg) for arg in non_none_args)
+        )
+    if origin is Literal:
+        return "Literal[{}]".format(", ".join(repr(arg) for arg in args))
+    if origin is not None:
+        name = getattr(origin, "__name__", str(origin).replace("typing.", ""))
+        if args:
+            return "{}[{}]".format(
+                name,
+                ", ".join(format_annotation(arg) for arg in args),
+            )
+        return name
+    return getattr(annotation, "__name__", str(annotation).replace("typing.", ""))
+
+
+# Used by the docstring renderer to decide when a generic field hint is useful.
+def annotation_allows_fields(annotation):
+    if annotation is inspect.Signature.empty:
+        return False
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    if origin in {Union, UnionType}:
+        args = tuple(arg for arg in args if arg is not type(None))
+        return bool(args) and any(annotation_allows_fields(arg) for arg in args)
+
+    if origin is not None:
+        if origin in {dict, Dict}:
+            return True
+        return False
+
+    if getattr(annotation, "__name__", None) == "AsList":
+        return False
+
+    return annotation not in {Any, str, int, float, bool, Path, type(None)}
+
+
+# The docstring renderer passes parameter descriptions here.
+# MkDocs object references are expanded into nested options when possible.
+def sanitize_help_lines(lines, base_indent, prefix=None):
+    result = []
+    skipping_indent = None
+    replacement = []
+    directive_re = re.compile(r"^\s*:::\s+([^\s]+)")
+
+    for line in lines:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+
+        if skipping_indent is not None:
+            match = directive_re.match(line)
+            if match is not None:
+                # replacement stores expanded object docs until the admonition ends.
+                replacement = format_linked_docstring(
+                    match.group(1),
+                    base_indent,
+                    prefix=prefix,
+                )
+            if not stripped or indent > skipping_indent:
+                continue
+            if replacement:
+                result.extend(replacement)
+                replacement = []
+            skipping_indent = None
+
+        if stripped.startswith("???"):
+            # MkDocs admonitions are omitted from CLI help.
+            # Their object directive is expanded if one appears inside.
+            skipping_indent = indent
+            replacement = []
+            continue
+        match = directive_re.match(line)
+        if match is not None:
+            result.extend(
+                format_linked_docstring(match.group(1), indent, prefix=prefix)
+            )
+            continue
+        result.append(" " * base_indent + line if line else "")
+
+    if skipping_indent is not None and replacement:
+        result.extend(replacement)
+
+    return result
+
+
+# Called for description cleanup for linked object references in docstrings.
+# The returned lines are inserted under the current option description.
+def format_linked_docstring(reference, base_indent, prefix=None):
+    parts = reference.split(".")
+    obj = None
+    # A reference can point to an attribute not just a module.
+    # Import the longest module prefix then traverse the rest as attributes.
+    for index in range(len(parts), 0, -1):
+        module_name = ".".join(parts[:index])
+        try:
+            obj = importlib.import_module(module_name)
+        except Exception:
+            continue
+        for part in parts[index:]:
+            try:
+                obj = getattr(obj, part)
+            except AttributeError:  # pragma: no cover
+                obj = None
+                break
+        if obj is not None:
+            break
+    if obj is None:  # pragma: no cover
+        return []
+
+    # For classes, init usually carries the configurable parameter docstring.
+    if inspect.isclass(obj):
+        candidates = [
+            getattr(obj, "__init__", None),
+            obj,
+            getattr(obj, "__call__", None),
+        ]
+    else:
+        candidates = [
+            obj,
+            getattr(obj, "__init__", None),
+            getattr(obj, "__call__", None),
+        ]
+    doc = None
+    target = None
+    for candidate in candidates:
+        doc = inspect.getdoc(candidate)
+        if doc and doc != "Call self as a function.":
+            target = candidate
+            break
+    if doc is None:  # pragma: no cover
+        return []
+
+    # params is used by the recursive docstring renderer to produce nested paths.
+    # Var keyword parameters are shown only for linked objects as field placeholders.
+    try:
+        signature = inspect.signature(target)
+    except (TypeError, ValueError):  # pragma: no cover
+        params = {}
+    else:
+        params = {
+            param.name: param
+            for param in signature.parameters.values()
+            if param.name not in {"self", "config_meta"}
+            and param.kind is not inspect.Parameter.VAR_POSITIONAL
+            and (prefix is not None or param.kind is not inspect.Parameter.VAR_KEYWORD)
+        }
+
+    indent = " " * base_indent
+    lines = [f"{indent}Details for {reference}:", ""]
+    formatted = format_cli_help_text(
+        doc,
+        params,
+        prefix=prefix,
+        include_parameters_heading=prefix is None,
+    )
+    for line in formatted.splitlines():
+        lines.append(indent + line if line else "")
+    return lines

--- a/confit/config.py
+++ b/confit/config.py
@@ -141,8 +141,17 @@ class Config(dict):
                     return loads(x.value)
                 return super().construct_object(x, deep)
 
+        def wrap_mapping(obj):
+            if isinstance(obj, Mapping):
+                return Config({k: wrap_mapping(v) for k, v in obj.items()})
+            if isinstance(obj, list):
+                return [wrap_mapping(v) for v in obj]
+            if isinstance(obj, tuple):
+                return tuple(wrap_mapping(v) for v in obj)
+            return obj
+
         stream = StringIO(s)
-        config = Config(yaml.load(stream, Loader=ConfitYamlLoader))
+        config = wrap_mapping(yaml.load(stream, Loader=ConfitYamlLoader))
         if resolve:
             return config.resolve(registry=registry)
 

--- a/confit/config.py
+++ b/confit/config.py
@@ -445,7 +445,7 @@ class Config(dict):
                     fn = registry_value.get(value)
                     try:
                         if is_draft:
-                            resolved = Draft(fn, params)
+                            resolved = Draft(fn, params, loc)
                         else:
                             resolved = fn(**params)
                         # The `validate_arguments` decorator has most likely

--- a/confit/draft.py
+++ b/confit/draft.py
@@ -16,6 +16,7 @@ from typing_extensions import ParamSpec, Protocol
 from confit.errors import (
     ConfitValidationError,
     ErrorWrapper,
+    patch_errors,
     to_legacy_error,
 )
 from confit.typing import cast
@@ -153,9 +154,11 @@ class Draft(Generic[R], metaclass=MetaDraft):
         self,
         func: Callable[P, R],
         kwargs: Dict[str, Any],
+        loc=(),
     ):
         self._func = func
         self._kwargs = kwargs
+        self._loc = tuple(loc)
         return_type = inspect.signature(func).return_annotation
         if isinstance(return_type, str):
             raise RuntimeError(
@@ -177,7 +180,14 @@ class Draft(Generic[R], metaclass=MetaDraft):
 
         # Order matters: priority is given to the kwargs provided
         # by the user, so most likely when the Partial is instantiated
-        res = self._func(**{**kwargs, **self._kwargs})
+        try:
+            res = self._func(**{**kwargs, **self._kwargs})
+        except ConfitValidationError as e:
+            raise ConfitValidationError(
+                patch_errors(e.raw_errors, self._loc, self._kwargs),
+                model=e.model,
+                name=getattr(e, "name", None),
+            ).with_traceback(e.__traceback__)
         return res
 
     def _raise_draft_error(self):

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -17,7 +17,7 @@ Confit also adds support for command-line interfaces by either passing a config 
 
 ### Typer
 
-[Typer](https://github.com/tiangolo/typer) is a CLI library that focuses on providing easy-to-use functionalities for building command-line interface. While Typer offers excellent CLI support and basic argument validation, it does not have configuration file-related features such as loading, exporting, or parameter validation like Confit does. Confit relies on Typer for its CLI support, but adds config file arguments and instantiating classes from a registry, both of which are not available in Typer.
+[Typer](https://github.com/tiangolo/typer) is a CLI library that focuses on providing easy-to-use functionalities for building command-line interface. While Typer offers excellent CLI support and basic argument validation, it does not have configuration file-related features such as loading, exporting, or parameter validation like Confit does. Confit's CLI is smaller and configuration-first, with readable help text, config file arguments and instantiating classes from a registry.
 
 However, if your primary focus is on building a robust CLI, Typer is a strong alternative.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,20 @@ class BigModel:
 
 + @app.command(name="script", registry=registry)
 def func(modelA: BigModel, modelB: BigModel, other: int, seed: int):
+    """
+    Run the configured models.
+
+    Parameters
+    ----------
+    modelA : BigModel
+        The first model.
+    modelB : BigModel
+        The second model.
+    other : int
+        Value printed by the command.
+    seed : int
+        Random seed.
+    """
     assert modelA.submodel is modelB.submodel
     assert modelA.date == datetime.date(2010, 10, 10)
     print("Other:", other)
@@ -114,6 +128,37 @@ Create a new config file
 
     You can pass multiple configuration files by repeating the `--config` option. Configuration will be merged in order.
 
+The same command also exposes a readable help message, including `--config`,
+typed parameters and nested field overrides:
+
+```bash { data-md-color-scheme="slate" }
+python script.py --help
+```
+
+```text
+Run the configured models.
+
+Parameters
+----------
+  --config <Path>
+    Load a config file to fill in the following params. Can be repeated.
+
+  --modelA <BigModel>
+    The first model.
+
+    --modelA.<field> VALUE
+
+  --modelB <BigModel>
+    The second model.
+
+    --modelB.<field> VALUE
+
+  --other <int>
+    Value printed by the command.
+
+  --seed <int>
+    Random seed.
+```
 
 You can still call the `function` method from your code, but now also benefit from argument validation !
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 Confit is a complete and easy-to-use configuration framework aimed at improving the reproducibility of experiments by relying on the Python typing system, minimal configuration files and command line interfaces.
 
 The three pillars of this configuration system are the [catalogue](https://github.com/explosion/catalogue) registry,
-the [Pydantic](https://github.com/pydantic/pydantic) validation system and the [typer](https://github.com/tiangolo/typer) CLI library.
+the [Pydantic](https://github.com/pydantic/pydantic) validation system and a small configuration-first CLI.
 
 ## Registry
 
@@ -50,7 +50,7 @@ Combined with our configuration system, dictionaries passed as arguments to a de
 
 ## CLI
 
-We provide the `confit.Cli` object, a Typer-based wrapper that turns a regular function into a command line interface. Once decorated with `@app.command`, the function can be executed from the terminal and automatically accepts one or several `--config` files containing its parameters, as well as parameter-wise overrides.
+We provide the `confit.Cli` object, a small wrapper that turns a regular function into a command line interface. Once decorated with `@app.command`, the function can be executed from the terminal and automatically accepts one or several `--config` files containing its parameters, as well as parameter-wise overrides.
 
 For instance, we'll decorate the `cool_function` function to make it available as a command line interface, and put some of its parameters in a configuration file `config.yml`:
 
@@ -78,6 +78,18 @@ def cool_function(
     modelB,
     seed: int = 0,
 ):
+    """
+    Train a model.
+
+    Parameters
+    ----------
+    modelA : MyClass
+        First model to use.
+    modelB
+        Second model to use.
+    seed : int
+        Random seed.
+    """
     ...
 
 
@@ -110,6 +122,33 @@ python script.py --config config.yml --seed 42
 
 Command line arguments override values from the configuration. If multiple
 configuration files are provided, they are merged in order.
+
+The generated help text is plain and mirrors the function docstring and type
+annotations:
+
+```bash
+python script.py --help
+```
+
+```text
+Train a model.
+
+Parameters
+----------
+  --config <Path>
+    Load a config file to fill in the following params. Can be repeated.
+
+  --modelA <MyClass>
+    First model to use.
+
+    --modelA.<field> VALUE
+
+  --modelB <Any>
+    Second model to use.
+
+  --seed <int> (default: 0)
+    Random seed.
+```
 
 ## The Config object
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,24 +9,24 @@ authors = [
 ]
 license = { file = "LICENSE" }
 readme = "README.md"
-requires-python = ">=3.7.1,<4.0"
+requires-python = ">=3.10,<4.0"
 dynamic = ['version']
 dependencies = [
-    "catalogue>=2.0.7,<3.0",
-    "lark>=1.1.5,<2.0",
-    "pydantic>=1.2,<3.0",
-    "typer>=0.6.1,<1.0",
+    "catalogue>=2.0.7",
+    "lark>=1.1.5",
+    "pydantic>=1.2",
     "pydantic-core>=0.20",
     "PyYAML",
-    "click<8.2",
+    "griffe",
 ]
 
 [dependency-groups]
 dev = [
-    "coverage>=7.0,<8.0",
-    "pre-commit>=2.18.1,<3.0",
-    "pytest>=7.1.1,<8.0",
-    "pytest-cov>=4.0.0,<5.0",
+    "coverage>=7.0",
+    "pre-commit>=2.18.1",
+    "pytest>=7.1.1",
+    "pytest-cov>=4.0.0",
+    "edsnlp[ml]",
     "rich",
     "torch",
     "numpy",
@@ -37,7 +37,7 @@ docs = [
 ]
 
 [tool.uv.dependency-groups]
-docs = {requires-python = ">=3.9"}
+docs = {requires-python = ">=3.10"}
 
 [tool.setuptools.dynamic]
 version = { attr = "confit.__version__" }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,10 @@ class CliRunner:
 
 
 runner = CliRunner()
+requires_pydantic_v2_for_edsnlp = pytest.mark.skipif(
+    PYDANTIC_V1,
+    reason="EDS-NLP tests require pydantic>=2",
+)
 
 
 def result_text(result):
@@ -289,6 +293,7 @@ def test_cli_help_shows_config_overrides():
     assert "v__duplicate_kwargs" not in help_text
 
 
+@requires_pydantic_v2_for_edsnlp
 def test_edsnlp_train_help_shows_config_overrides():
     try:
         edsnlp_train = pytest.importorskip("edsnlp.train")
@@ -335,6 +340,7 @@ def test_edsnlp_train_help_shows_config_overrides():
     assert "v__duplicate_kwargs" not in help_text
 
 
+@requires_pydantic_v2_for_edsnlp
 def test_edsnlp_train_missing_pipe_parameter_error(tmp_path):
     try:
         edsnlp_train = pytest.importorskip("edsnlp.train")
@@ -376,6 +382,7 @@ train:
     assert "field required" in text
 
 
+@requires_pydantic_v2_for_edsnlp
 def test_edsnlp_train_optimizer_parameter_error(tmp_path):
     try:
         edsnlp_train = pytest.importorskip("edsnlp.train")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,6 +335,93 @@ def test_edsnlp_train_help_shows_config_overrides():
     assert "v__duplicate_kwargs" not in help_text
 
 
+def test_edsnlp_train_missing_pipe_parameter_error(tmp_path):
+    try:
+        edsnlp_train = pytest.importorskip("edsnlp.train")
+        from edsnlp.core.registries import registry as edsnlp_registry
+
+        set_default_registry(edsnlp_registry)
+        config_path = tmp_path / "missing-pipe-param.yml"
+        config_path.write_text(
+            """
+nlp:
+  '@core': pipeline
+  lang: eds
+  components:
+    qualifier:
+      '@factory': eds.span_classifier
+      attributes: [ 'negation' ]
+      span_getter: [ 'ents' ]
+
+train_data: []
+
+train:
+  nlp: ${nlp}
+  train_data: ${train_data}
+  max_steps: 1
+  cpu: true
+  logger: false
+"""
+        )
+
+        result = runner.invoke(edsnlp_train.app, ["--config", str(config_path)])
+    finally:
+        set_default_registry(registry)
+
+    text = result_text(result)
+    assert result.exit_code == 1
+    assert "Validation error: 1 validation error for " in text
+    assert "TrainableSpanClassifier()" in text
+    assert "-> train.nlp.components.qualifier.embedding" in text
+    assert "field required" in text
+
+
+def test_edsnlp_train_optimizer_parameter_error(tmp_path):
+    try:
+        edsnlp_train = pytest.importorskip("edsnlp.train")
+        from edsnlp.core.registries import registry as edsnlp_registry
+
+        set_default_registry(edsnlp_registry)
+        config_path = tmp_path / "bad-optimizer-param.yml"
+        config_path.write_text(
+            f"""
+nlp:
+  '@core': pipeline
+  lang: eds
+
+optimizer:
+  '@core': optimizer !draft
+  optim: AdamW
+  groups:
+    '.*':
+      lr: 1e-3
+  total_steps: invalid
+
+train_data: []
+
+train:
+  nlp: ${{nlp}}
+  train_data: ${{train_data}}
+  max_steps: 1
+  cpu: true
+  logger: false
+  output_dir: {str(tmp_path / "train-artifacts")!r}
+  optimizer: ${{optimizer}}
+"""
+        )
+
+        result = runner.invoke(edsnlp_train.app, ["--config", str(config_path)])
+    finally:
+        set_default_registry(registry)
+
+    text = result_text(result)
+    assert result.exit_code == 1
+    assert "Validation error: 1 validation error for ScheduledOptimizer()" in text
+    assert "-> train.optimizer.total_steps" in text
+    assert "input should be a valid integer" in text
+    assert "got 'invalid' (str)" in text
+
+
 def test_cli_missing_debug(change_test_dir):
     result = runner.invoke(
         app,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,78 @@
 import datetime
+import io
+import os
 import random
+import re
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from typing import List, Literal, Optional, Union
 
 import pytest
-from typer.testing import CliRunner
 
 from confit import Cli, Config, Registry
 from confit.registry import PYDANTIC_V1, RegistryCollection, set_default_registry
 
+
+@dataclass
+class CliResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    exception: Exception | None = None
+
+    @property
+    def output(self):
+        return self.stdout + self.stderr
+
+
+class CliRunner:
+    def invoke(self, app, args, env=None):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        previous_env = os.environ.copy()
+        if env is not None:
+            os.environ.update(env)
+        try:
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                app.main(args=list(args))
+            return CliResult(0, stdout.getvalue(), stderr.getvalue())
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else 1
+            return CliResult(code, stdout.getvalue(), stderr.getvalue(), e)
+        except Exception as e:
+            return CliResult(1, stdout.getvalue(), stderr.getvalue(), e)
+        finally:
+            os.environ.clear()
+            os.environ.update(previous_env)
+
+
 runner = CliRunner()
+
+
+def result_text(result):
+    return "\n".join(
+        str(part)
+        for part in (result.output, result.stdout, result.stderr, result.exception)
+        if part
+    )
+
+
+def make_multi_command_app():
+    multi_app = Cli(pretty_exceptions_show_locals=False)
+
+    @multi_app.command(name="first")
+    def first(value: int = 1):
+        print(f"first: {value}")
+
+    @multi_app.command(name="second")
+    def second(value: int = 2):
+        print(f"second: {value}")
+
+    return multi_app
+
+
+def strip_ansi(text):
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 class registry(RegistryCollection):
@@ -19,6 +84,33 @@ set_default_registry(registry)
 
 class CustomClass:
     pass
+
+
+class LinkedHelpModel:
+    def __init__(self, value: int, label: str = "default"):
+        """
+        Linked help target.
+
+        Parameters
+        ----------
+        value : int
+            Nested value.
+        label : str
+            Nested label.
+        """
+
+
+def linked_help_function(value: int, enabled: bool = True):
+    """
+    Linked function help target.
+
+    Parameters
+    ----------
+    value : int
+        Function value.
+    enabled : bool
+        Whether it is enabled.
+    """
 
 
 @registry.factory.register("submodel")
@@ -62,6 +154,187 @@ def test_cli_working(change_test_dir):
     assert "Other: 4" in result.stdout
 
 
+def test_cli_call_delegates_to_main():
+    call_app = Cli(pretty_exceptions_show_locals=False)
+
+    @call_app.command(name="script")
+    def call_command():
+        print("called")
+
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        call_app([])
+
+    assert stdout.getvalue() == "called\n"
+
+
+def test_cli_explicit_command_in_multi_command_app():
+    multi_app = make_multi_command_app()
+    result = runner.invoke(multi_app, ["first", "--value", "3"])
+
+    assert result.exit_code == 0, result_text(result)
+    assert result.stdout == "first: 3\n"
+
+
+def test_cli_multi_command_top_level_help():
+    multi_app = make_multi_command_app()
+    result = runner.invoke(multi_app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Commands:\n  first\n  second" in result.stdout
+
+
+def test_cli_multi_command_without_command_args_shows_help():
+    multi_app = make_multi_command_app()
+    result = runner.invoke(multi_app, ["first"])
+
+    assert result.exit_code == 0
+    assert "Commands:\n  first\n  second" in result.stdout
+
+
+def test_cli_accepts_config_equals_path(change_test_dir):
+    result = runner.invoke(
+        app,
+        [
+            "--config=config.cfg",
+            "--modelA.date",
+            "2010-10-10",
+            "--other",
+            "4",
+            "--seed=42",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Other: 4" in result.stdout
+
+
+def test_cli_help_formats_common_annotations():
+    help_app = Cli(pretty_exceptions_show_locals=False)
+
+    @help_app.command(name="script")
+    def typed_command(
+        untyped,
+        maybe: Optional[int] = None,
+        choice: Literal["small", "large"] = "small",
+        numbers: list[int] | None = None,
+        lookup: dict[str, int] | None = None,
+        legacy_values: List = None,
+        either: Union[int, str] = 1,
+    ):
+        pass
+
+    result = runner.invoke(help_app, ["--help"])
+
+    help_text = strip_ansi(result.stdout)
+    assert result.exit_code == 0
+    assert "--untyped <Any>" in help_text
+    assert "--maybe <Optional[int]> (default: None)" in help_text
+    assert "--choice <Literal['small', 'large']> (default: 'small')" in help_text
+    assert "--numbers <Optional[list[int]]> (default: None)" in help_text
+    assert "--lookup <Optional[dict[str, int]]> (default: None)" in help_text
+    assert "--lookup.<field> VALUE" in help_text
+    assert "--legacy_values <list> (default: None)" in help_text
+    assert "--either <Union[int, str]> (default: 1)" in help_text
+
+
+def test_cli_help_expands_linked_docstrings():
+    linked_app = Cli(pretty_exceptions_show_locals=False)
+
+    @linked_app.command(name="script")
+    def linked_command(model: dict, direct: dict):
+        pass
+
+    linked_app.commands["script"]["fn"].__doc__ = f"""
+    Run linked help.
+
+    Parameters
+    ----------
+    model : dict
+        Model settings.
+
+        ??? note
+            ::: {__name__}.LinkedHelpModel
+        More model details.
+    direct : dict
+        ::: {__name__}.linked_help_function
+    """
+
+    result = runner.invoke(linked_app, ["--help"])
+
+    help_text = strip_ansi(result.stdout)
+    assert result.exit_code == 0
+    assert f"Details for {__name__}.LinkedHelpModel:" in help_text
+    assert f"Details for {__name__}.linked_help_function:" in help_text
+    assert "More model details." in help_text
+    assert "--model.value <int>" in help_text
+    assert "--model.label <str>" in help_text
+    assert "--direct.value <int>" in help_text
+    assert "--direct.enabled <bool>" in help_text
+    assert "???" not in help_text
+    assert ":::" not in help_text
+
+
+def test_cli_help_shows_config_overrides():
+    result = runner.invoke(app, ["--help"])
+    help_text = strip_ansi(result.stdout)
+    assert result.exit_code == 0, result.stdout
+    assert "\x1b[1m--modelA\x1b[0m" in result.stdout
+    assert "Confit overrides:" not in help_text
+    assert "--config <Path>" in help_text
+    assert "Load a config file to fill in the following params" in help_text
+    assert "--modelA <BigModel>" in help_text
+    assert "--modelA.<field> VALUE" in help_text
+    assert "--other <int>" in help_text
+    assert "v__duplicate_kwargs" not in help_text
+
+
+def test_edsnlp_train_help_shows_config_overrides():
+    try:
+        edsnlp_train = pytest.importorskip("edsnlp.train")
+        from edsnlp.core.registries import registry as edsnlp_registry
+
+        set_default_registry(edsnlp_registry)
+        result = runner.invoke(edsnlp_train.app, ["--help"])
+    finally:
+        set_default_registry(registry)
+
+    help_text = strip_ansi(result.stdout)
+    assert result.exit_code == 0, result.stdout
+    assert "\x1b[1m--train_data\x1b[0m" in result.stdout
+    assert "Train a pipeline.\n\nParameters" in help_text
+    assert "Confit overrides:" not in help_text
+    assert "--config <Path>" in help_text
+    assert "Load a config file to fill in the following params" in help_text
+    assert "--nlp <Pipeline>" in help_text
+    assert "--nlp.<field> VALUE" in help_text
+    assert "--config <Path>\n    Load a config file" in help_text
+    assert "--nlp <Pipeline>\n    The pipeline" in help_text
+    assert "--nlp.<field> VALUE\n\n  --train_data" in help_text
+    assert "--train_data <AsList[TrainingData]>" in help_text
+    assert "--train_data.data <Stream>" in help_text
+    assert "--train_data.batch_size <BatchSizeArg>" in help_text
+    assert "--max_steps <int> (default: 1000)" in help_text
+    assert "--seed <int> (default: 42)" in help_text
+    assert "--validation_interval <Optional[int]> (default: None)" in help_text
+    assert "--validation_interval.<field> VALUE" not in help_text
+    assert "Details for edsnlp.training.trainer.TrainingData:" in help_text
+    assert "A training data object." in help_text
+    assert "Details for edsnlp.training.optimizer.ScheduledOptimizer:" in help_text
+    assert "Wrapper optimizer that supports schedules" in help_text
+    assert "Base class for all optimizers." not in help_text
+    assert "Details for edsnlp.training.trainer.GenericScorer:" in help_text
+    assert "--scorer.batch_size <Union[int, str]>" in help_text
+    assert "--scorer.speed <bool>" in help_text
+    assert "--scorer.autocast <Union[bool, Any]>" in help_text
+    assert "--scorer.metrics.<field> <Any>" in help_text
+    assert "--scorer.<field> VALUE" not in help_text
+    assert "Returns" not in help_text
+    assert ":::" not in help_text
+    assert "only_parameters" not in help_text
+    assert "v__duplicate_kwargs" not in help_text
+
+
 def test_cli_missing_debug(change_test_dir):
     result = runner.invoke(
         app,
@@ -98,13 +371,14 @@ def test_cli_missing_no_debug(change_test_dir):
         ],
     )
     assert result.exit_code == 1
+    text = result_text(result)
+    assert ("2 validation errors for ") in text
     assert (
-        "2 validation errors for test_cli.function()\n"
         "-> script.modelA.submodel\n"
         "   field required\n"
         "-> script.modelB\n"
         "   field required"
-    ) in str(result.stdout)
+    ) in text
 
 
 def test_cli_merge(change_test_dir):
@@ -418,11 +692,8 @@ value = 44
     # This should fail because modelA is not defined and we're not merging
     # with default
     assert result.exit_code == 1
-    assert (
-        "field required" in str(result.stdout)
-        or "field required" in str(result.exception)
-        or "modelA" in str(result.exception)
-    )
+    text = result_text(result)
+    assert "field required" in text or "modelA" in text
 
 
 def test_cli_default_config_with_command_line_override():

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -673,6 +673,33 @@ params:
     assert config["params"]["c"] == 1
 
 
+def test_yaml_string_operation_inside_interpolation():
+    config = Config.from_yaml_str(
+        """\
+params:
+    field: ${section.string + "_suffix"}
+
+section:
+    string: value
+"""
+    ).resolve()
+    assert config["params"]["field"] == "value_suffix"
+
+
+def test_yaml_subconfig_resolve_with_root():
+    config = Config.from_yaml_str(
+        """\
+params:
+    field: ${section.string + "_suffix"}
+
+section:
+    string: value
+"""
+    )
+    assert isinstance(config["params"], Config)
+    assert config["params"].resolve(root=config)["field"] == "value_suffix"
+
+
 def test_if_else_complex():
     config = Config.from_yaml_str(
         """\


### PR DESCRIPTION
## Description

- Fix indexing: `Config.from_yaml_str(...)[key]` is now a Config object if it's a mapping
- Drop typer and click, and handle the CLI ourselves, with better rendering for complex functions
- Fix, correctly locate param error in error log when using Draft objects

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
