### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.11.0 (2026-06-15)
 
 - Fix indexing: `Config.from_yaml_str(...)[key]` is now a Config object if it's a mapping
 - Drop typer and click, and handle the CLI ourselves, with better rendering for complex functions

--- a/confit/_version.py
+++ b/confit/_version.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-__version__ = "0.10.2"
+__version__ = "0.11.0"
 
 
 def get_version(base_version: str = __version__) -> str:


### PR DESCRIPTION
<!-- Edit the release message between the markers before merging this PR. -->
<!-- release-message:start -->
## Changelog

- Fix indexing: `Config.from_yaml_str(...)[key]` is now a Config object if it's a mapping
- Drop typer and click, and handle the CLI ourselves, with better rendering for complex functions
- Fix, correctly locate param error in error log when using Draft objects
- Don't fail but warn, when we suspect that un unquoted string might actually be an object in config files.
- Improved typing checks for drafts: we forbid string type hints, as we cannot validate against them

## Pull Requests
* fix: warn instead of fail when suspecting malformed configs by @percevalw in https://github.com/aphp/confit/pull/44
* Fail draft string types by @percevalw in https://github.com/aphp/confit/pull/45
* Improved CLI by @percevalw in https://github.com/aphp/confit/pull/46
* ci: add automated PR release workflow by @percevalw in https://github.com/aphp/confit/pull/47


**Full Changelog**: https://github.com/aphp/confit/compare/v0.10.2...v0.11.0
<!-- release-message:end -->
