### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Explicit version to release, e.g. 0.11.0"
+        description: "Explicit version to release, e.g. 0.11.1"
         required: false
         type: string
       bump:

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.11.1 (2026-06-15)
 
 - Fix package source discovery
 

--- a/confit/_version.py
+++ b/confit/_version.py
@@ -4,7 +4,7 @@ import subprocess
 from importlib import metadata
 from pathlib import Path
 
-_BASE_VERSION = "0.11.0"
+_BASE_VERSION = "0.11.1"
 
 
 def get_version(base_version: str = _BASE_VERSION) -> str:

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -66,7 +66,7 @@ def run(
 def normalize_version(version: str) -> str:
     if not re.fullmatch(r"\d+\.\d+\.\d+", version):
         raise ReleaseError(
-            f"Invalid version '{version}'. Expected a semantic version like 0.11.0."
+            f"Invalid version '{version}'. Expected a semantic version like 0.11.1."
         )
     return version
 
@@ -385,7 +385,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "version",
         nargs="?",
-        help="Target version, for example 0.11.0",
+        help="Target version, for example 0.11.1",
     )
     parser.add_argument(
         "--bump",


### PR DESCRIPTION
<!-- Edit the release message between the markers before merging this PR. -->
<!-- release-message:start -->
## Changelog

- Fix package source discovery

**Full Changelog**: https://github.com/aphp/confit/compare/v0.11.0...v0.11.1
<!-- release-message:end -->
