### PR TITLE
feat: allow choosing between configs for multi recorded instantiated objects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- When a class instantiation is recorded by multiple factories (e.g. edsnlp's `load_pipe` which in turns calls the pipe architecture factory), we don't overwrite the instance origin and instead make it accessible to the config serializer via `__confit_serialization_origin__ = 'first'|'last'` on registered objects to decide which factory config to use when serializing the object.
+
 ## v0.11.1 (2026-06-15)
 
 - Fix package source discovery

--- a/confit/config.py
+++ b/confit/config.py
@@ -24,6 +24,7 @@ from confit.utils.settings import is_debug
 from confit.utils.xjson import Reference, dumps, loads
 
 RESOLVED_TO_CONFIG = WeakKeyDictionary()
+RESOLVED_TO_CONFIGS = WeakKeyDictionary()
 
 Loc = Tuple[Union[int, str]]
 T = TypeVar("T")
@@ -207,6 +208,9 @@ class Config(dict):
         Try to convert non-serializable objects using the RESOLVED_TO_CONFIG object
         back to their original catalogue + params form
 
+        Objects can set `__confit_serialization_origin__` to `"first"` to use
+        their first recorded origin instead of the latest origin
+
         We try to preserve referential equalities between non dict/list/tuple
         objects by serializing subsequent references to the same object as references
         to its first occurrence in the tree.
@@ -258,7 +262,13 @@ class Config(dict):
                 return type(o)(rec(v, (*path, i)) for i, v in enumerate(o))
             cfg = None
             try:
-                cfg = (cfg or Config()).merge(RESOLVED_TO_CONFIG[o])
+                try:
+                    origins = RESOLVED_TO_CONFIGS[o]
+                    origin = getattr(o, "__confit_serialization_origin__", "last")
+                    origin_config = origins[0] if origin == "first" else origins[-1]
+                except KeyError:
+                    origin_config = RESOLVED_TO_CONFIG[o]
+                cfg = (cfg or Config()).merge(origin_config)
             except (KeyError, TypeError):
                 pass
             try:
@@ -598,7 +608,7 @@ class Config(dict):
     @classmethod
     def _store_resolved(cls, resolved: Any, config: Dict[str, Any]):
         """
-        Adds a resolved object to the RESOLVED_TO_CONFIG dict
+        Adds a resolved object and its origin to the serialization mappings
         for later retrieval during serialization
         ([`.serialize`][confit.config.Config.serialize])
 
@@ -609,6 +619,8 @@ class Config(dict):
         """
         try:
             RESOLVED_TO_CONFIG[resolved] = config
+            origins = RESOLVED_TO_CONFIGS.setdefault(resolved, [])
+            origins.append(config)
         except TypeError:
             pass
 

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -17,9 +17,24 @@ class CustomClass:
     pass
 
 
+class FirstOriginClass:
+    __confit_serialization_origin__ = "first"
+
+
 class HeldValue:
     def __init__(self):
         self.value = "A value!"
+
+
+def test_serialization_origin_selection():
+    latest = CustomClass()
+    first = FirstOriginClass()
+    for instance in (latest, first):
+        Config._store_resolved(instance, {"origin": "constructor"})
+        Config._store_resolved(instance, {"origin": "user"})
+
+    assert Config.serialize(latest) == {"origin": "user"}
+    assert Config.serialize(first) == {"origin": "constructor"}
 
 
 @registry.factory.register("submodel")


### PR DESCRIPTION
## Description

- When a class instantiation is recorded by multiple factories (e.g. edsnlp's `load_pipe` which in turns calls the pipe architecture factory), we don't overwrite the instance origin and instead make it accessible to the config serializer via `__confit_serialization_origin__ = 'first'|'last'` on registered objects to decide which factory config to use when serializing the object.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
